### PR TITLE
Fixes 'dimensiosn' typo in schema field name.

### DIFF
--- a/src/SingleGaussianPsf.cc
+++ b/src/SingleGaussianPsf.cc
@@ -59,7 +59,7 @@ private:
         schema(),
         dimensions(
             schema.addField< afw::table::Point<int> >(
-                "dimensiosn", "width/height of realization of Psf", "pixels"
+                "dimensions", "width/height of realization of Psf", "pixels"
             )
         ),
         sigma(schema.addField<double>("sigma", "radius of Gaussian", "pixels"))


### PR DESCRIPTION
Fixed typo.
Couldn't create branch with lsst/meas_algorithms, so couldn't run a buildbot.