### PR TITLE
Wrap matplotlib.pyplot import in RuntimeError in addition to ImportError

### DIFF
--- a/python/lsst/meas/algorithms/objectSizeStarSelector.py
+++ b/python/lsst/meas/algorithms/objectSizeStarSelector.py
@@ -25,7 +25,7 @@ import numpy
 try:
     import matplotlib.pyplot as pyplot
     fig = None
-except ImportError:
+except (ImportError, RuntimeError):
     pyplot = None
 
 import lsst.pex.config as pexConfig

--- a/python/lsst/meas/algorithms/utils.py
+++ b/python/lsst/meas/algorithms/utils.py
@@ -325,7 +325,7 @@ def showPsfCandidates(exposure, psfCellSet, psf=None, frame=None, normalize=True
 try:
     import matplotlib.pyplot as plt
     import matplotlib.colors
-except ImportError:
+except (ImportError, RuntimeError):
     plt = None
 
 def makeSubplots(fig, nx=2, ny=2, Nx=1, Ny=1, plottingArea=(0.1, 0.1, 0.85, 0.80),


### PR DESCRIPTION
Passes buildbot 
http://lsst-buildx.ncsa.illinois.edu:8010/builders/DM_stack/builds/5664

Moderate discussion of how to do plotting "right" in general and what should be caught, etc., and what should be wrapped by a general plotting import function at
https://jira.lsstcorp.org/browse/DM-2588
But I recommend that that discussion be preserved for a future general fix, and this simple catching of both ImportException, RuntimeException be accepted for a pragmatic fix for this.