### PR TITLE
Only take median position when points exist.

### DIFF
--- a/python/lsst/meas/algorithms/objectSizeStarSelector.py
+++ b/python/lsst/meas/algorithms/objectSizeStarSelector.py
@@ -192,7 +192,12 @@ def _kcenters(yvec, nCluster, useMedian=False, widthStdAllowed=0.15):
             break
 
         for i in range(nCluster):
-            centers[i] = func(yvec[clusterId == i])
+            # Only compute func if some points are available; otherwise, default to NaN.
+            pointsInCluster = (clusterId == i)
+            if numpy.any(pointsInCluster):
+                centers[i] = func(yvec[pointsInCluster])
+            else:
+                centers[i] = numpy.nan
 
     return centers, clusterId
 


### PR DESCRIPTION
Previously, when attempted to take the median position of a list of points we
relied on the (old, pre-1.10) NumPy behaviour of providing NaN as the median
of an empty array. Newer NumPy will raise an ImportError instead. Here, we
explicitly check that we have at least one point before taking the median.