### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/meas/algorithms/BinnedWcs.h
+++ b/include/lsst/meas/algorithms/BinnedWcs.h
@@ -25,7 +25,7 @@
 #ifndef LSST_MEAS_ALGORITHMS_BINNEDWCS_H
 #define LSST_MEAS_ALGORITHMS_BINNEDWCS_H
 
-#include <boost/enable_shared_from_this.hpp>
+#include <memory>
 
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/image/Wcs.h"
@@ -38,7 +38,7 @@ namespace lsst { namespace meas { namespace algorithms {
 LSST_EXCEPTION_TYPE(NotImplementedException, lsst::pex::exceptions::RuntimeError,
                     lsst::meas::algorithms::NotImplementedException);
 
-class BinnedWcs : public afw::image::Wcs, public boost::enable_shared_from_this<BinnedWcs> {
+class BinnedWcs : public afw::image::Wcs, public std::enable_shared_from_this<BinnedWcs> {
 public:
     BinnedWcs(PTR(afw::image::Wcs) parent, unsigned int xBin, unsigned int yBin, afw::geom::Point2I xy0);
     virtual ~BinnedWcs() {}

--- a/include/lsst/meas/algorithms/CR.h
+++ b/include/lsst/meas/algorithms/CR.h
@@ -42,7 +42,7 @@ namespace meas {
 namespace algorithms {
 
 template <typename MaskedImageT>
-std::vector<boost::shared_ptr<lsst::afw::detection::Footprint> >
+std::vector<std::shared_ptr<lsst::afw::detection::Footprint> >
 findCosmicRays(MaskedImageT& image,
                lsst::afw::detection::Psf const &psf,
                double const bkgd,

--- a/include/lsst/meas/algorithms/CoaddPsf.h
+++ b/include/lsst/meas/algorithms/CoaddPsf.h
@@ -24,7 +24,7 @@
 #if !defined(LSST_MEAS_ALGORITHMS_COADDPSF_H)
 #define LSST_MEAS_ALGORITHMS_COADDPSF_H
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include "lsst/base.h"
 #include "lsst/meas/algorithms/ImagePsf.h"
 #include "lsst/afw/image/Wcs.h"

--- a/include/lsst/meas/algorithms/ExposurePatch.h
+++ b/include/lsst/meas/algorithms/ExposurePatch.h
@@ -88,7 +88,7 @@ PTR(ExposurePatch<ExposureT>) makeExposurePatch(
     CONST_PTR(afw::detection::Footprint) foot,
     afw::geom::Point2D const& center
     ) {
-    return boost::make_shared<ExposurePatch<ExposureT> >(exp, foot, center);
+    return std::make_shared<ExposurePatch<ExposureT> >(exp, foot, center);
 }
 template<typename ExposureT>
 PTR(ExposurePatch<ExposureT>) makeExposurePatch(
@@ -97,7 +97,7 @@ PTR(ExposurePatch<ExposureT>) makeExposurePatch(
     afw::geom::Point2D const& standardCenter,
     afw::image::Wcs const& standardWcs
     ) {
-    return boost::make_shared<ExposurePatch<ExposureT> >(exp, standardFoot, standardCenter, standardWcs);
+    return std::make_shared<ExposurePatch<ExposureT> >(exp, standardFoot, standardCenter, standardWcs);
 }
 
 }}} // namespace

--- a/include/lsst/meas/algorithms/ImagePca.h
+++ b/include/lsst/meas/algorithms/ImagePca.h
@@ -34,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "lsst/afw.h"
 

--- a/include/lsst/meas/algorithms/ImagePca.h
+++ b/include/lsst/meas/algorithms/ImagePca.h
@@ -31,10 +31,9 @@
  *
  * @ingroup algorithms
  */
+#include <memory>
 #include <utility>
 #include <vector>
-
-#include <memory>
 
 #include "lsst/afw.h"
 

--- a/include/lsst/meas/algorithms/Interp.h
+++ b/include/lsst/meas/algorithms/Interp.h
@@ -69,7 +69,7 @@ namespace interp {
  */
 class Defect : public lsst::afw::image::DefectBase {
 public:
-    typedef boost::shared_ptr<Defect> Ptr; //!< shared pointer to Defect
+    typedef std::shared_ptr<Defect> Ptr; //!< shared pointer to Defect
 
     enum DefectPosition {
         LEFT = 1,                       //!< defect is at left boundary

--- a/include/lsst/meas/algorithms/PsfCandidate.h
+++ b/include/lsst/meas/algorithms/PsfCandidate.h
@@ -33,7 +33,7 @@
  */
 #include <vector>
 
-#include "boost/make_shared.hpp"
+#include <memory>
 
 #include "lsst/pex/policy.h"
 

--- a/include/lsst/meas/algorithms/PsfCandidate.h
+++ b/include/lsst/meas/algorithms/PsfCandidate.h
@@ -62,8 +62,8 @@ namespace algorithms {
         using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::getWidth;
         using lsst::afw::math::SpatialCellMaskedImageCandidate<PixelT>::getHeight;
     
-        typedef boost::shared_ptr<PsfCandidate<PixelT> > Ptr;
-        typedef boost::shared_ptr<const PsfCandidate<PixelT> > ConstPtr;
+        typedef std::shared_ptr<PsfCandidate<PixelT> > Ptr;
+        typedef std::shared_ptr<const PsfCandidate<PixelT> > ConstPtr;
         typedef std::vector<Ptr > PtrList;
 
         typedef lsst::afw::image::MaskedImage<PixelT> MaskedImageT;
@@ -184,12 +184,12 @@ namespace algorithms {
      * Cf. std::make_pair
      */
     template <typename PixelT>
-    boost::shared_ptr<PsfCandidate<PixelT> >
+    std::shared_ptr<PsfCandidate<PixelT> >
     makePsfCandidate(PTR(afw::table::SourceRecord) const& source, ///< The detected Source
                      PTR(afw::image::Exposure<PixelT>) image    ///< The image wherein lies the object
                     )
     {
-        return boost::make_shared< PsfCandidate<PixelT> >(source, image);
+        return std::make_shared< PsfCandidate<PixelT> >(source, image);
     }
    
 }}}

--- a/include/lsst/meas/algorithms/PsfCandidate.h
+++ b/include/lsst/meas/algorithms/PsfCandidate.h
@@ -31,9 +31,8 @@
  *
  * @ingroup algorithms
  */
-#include <vector>
-
 #include <memory>
+#include <vector>
 
 #include "lsst/pex/policy.h"
 

--- a/include/lsst/meas/algorithms/Shapelet.h
+++ b/include/lsst/meas/algorithms/Shapelet.h
@@ -33,7 +33,7 @@
  */
 #include <complex>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 
 #include "lsst/afw/table/Source.h"
@@ -91,8 +91,8 @@ namespace algorithms {
 
     public:
         typedef float PixelT;
-        typedef boost::shared_ptr<Shapelet> Ptr;
-        typedef boost::shared_ptr<const Shapelet> ConstPtr;
+        typedef std::shared_ptr<Shapelet> Ptr;
+        typedef std::shared_ptr<const Shapelet> ConstPtr;
 
         typedef Eigen::VectorXd ShapeletVector;
         typedef Eigen::MatrixXd ShapeletCovariance;
@@ -204,7 +204,7 @@ namespace algorithms {
         /*!
          * @brief get the covariance matrix
          */
-        boost::shared_ptr<const ShapeletCovariance> getCovariance() const;
+        std::shared_ptr<const ShapeletCovariance> getCovariance() const;
 
         /*!
          * @brief set a new value of sigma

--- a/include/lsst/meas/algorithms/Shapelet.h
+++ b/include/lsst/meas/algorithms/Shapelet.h
@@ -32,8 +32,8 @@
  * @author Mike Jarvis
  */
 #include <complex>
-
 #include <memory>
+
 #include "Eigen/Core"
 
 #include "lsst/afw/table/Source.h"

--- a/include/lsst/meas/algorithms/ShapeletInterpolation.h
+++ b/include/lsst/meas/algorithms/ShapeletInterpolation.h
@@ -33,7 +33,7 @@
  */
 #include <complex>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "Eigen/Core"
 
 #include "lsst/pex/policy/Policy.h"
@@ -69,8 +69,8 @@ namespace algorithms {
          */
     public:
 
-        typedef boost::shared_ptr<ShapeletInterpolation> Ptr;
-        typedef boost::shared_ptr<const ShapeletInterpolation> ConstPtr;
+        typedef std::shared_ptr<ShapeletInterpolation> Ptr;
+        typedef std::shared_ptr<const ShapeletInterpolation> ConstPtr;
 
         typedef float PixelT;
         typedef lsst::pex::policy::Policy Policy;

--- a/include/lsst/meas/algorithms/ShapeletInterpolation.h
+++ b/include/lsst/meas/algorithms/ShapeletInterpolation.h
@@ -32,8 +32,8 @@
  * @author Mike Jarvis
  */
 #include <complex>
-
 #include <memory>
+
 #include "Eigen/Core"
 
 #include "lsst/pex/policy/Policy.h"

--- a/include/lsst/meas/algorithms/ShapeletKernel.h
+++ b/include/lsst/meas/algorithms/ShapeletKernel.h
@@ -36,7 +36,7 @@
  *
  * @author Mike Jarvis
  */
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "lsst/afw/math/Kernel.h"
 #include "lsst/afw/image/Image.h"
@@ -87,8 +87,8 @@ namespace algorithms {
          */
 
     public :
-        typedef boost::shared_ptr<LocalShapeletKernel> Ptr;
-        typedef boost::shared_ptr<const LocalShapeletKernel> ConstPtr;
+        typedef std::shared_ptr<LocalShapeletKernel> Ptr;
+        typedef std::shared_ptr<const LocalShapeletKernel> ConstPtr;
 
         typedef lsst::afw::math::AnalyticKernel base;
         typedef lsst::afw::geom::Point2D Point;
@@ -166,8 +166,8 @@ namespace algorithms {
          * rather than one component at a time.
          */
     public :
-        typedef boost::shared_ptr<ShapeletKernel> Ptr;
-        typedef boost::shared_ptr<const ShapeletKernel> ConstPtr;
+        typedef std::shared_ptr<ShapeletKernel> Ptr;
+        typedef std::shared_ptr<const ShapeletKernel> ConstPtr;
 
         typedef lsst::afw::math::AnalyticKernel base;
         typedef lsst::afw::geom::Point2D Point;

--- a/include/lsst/meas/algorithms/ShapeletPsfCandidate.h
+++ b/include/lsst/meas/algorithms/ShapeletPsfCandidate.h
@@ -33,7 +33,7 @@
 
 #include "lsst/afw/math/SpatialCell.h"
 #include "lsst/afw/table/Source.h"
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 namespace lsst {
 namespace meas {
@@ -46,8 +46,8 @@ namespace algorithms {
         typedef lsst::afw::math::SpatialCellCandidate base;
         typedef lsst::afw::table::SourceRecord Source;
 
-        typedef boost::shared_ptr<ShapeletPsfCandidate> Ptr;
-        typedef boost::shared_ptr<const ShapeletPsfCandidate> ConstPtr;
+        typedef std::shared_ptr<ShapeletPsfCandidate> Ptr;
+        typedef std::shared_ptr<const ShapeletPsfCandidate> ConstPtr;
 
         /*!
          * @brief Constructor takes position, size, and original source

--- a/include/lsst/meas/algorithms/SizeMagnitudeStarSelector.h
+++ b/include/lsst/meas/algorithms/SizeMagnitudeStarSelector.h
@@ -31,7 +31,7 @@
  *
  * @author Mike Jarvis
  */
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "lsst/afw/table/Source.h"
 #include "lsst/afw/table/Match.h"  // because we can't forward-declare a typedef
@@ -123,7 +123,7 @@ namespace algorithms {
         SizeMagnitudeStarSelector(const SizeMagnitudeStarSelector& rhs);
         void operator=(const SizeMagnitudeStarSelector& rhs);
 
-        boost::shared_ptr<SizeMagnitudeStarSelectorImpl> pImpl;
+        std::shared_ptr<SizeMagnitudeStarSelectorImpl> pImpl;
     };
 
 }}}

--- a/include/lsst/meas/algorithms/SpatialModelPsf.h
+++ b/include/lsst/meas/algorithms/SpatialModelPsf.h
@@ -34,7 +34,7 @@
 #include <utility>
 #include <vector>
 
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "lsst/afw.h"
 #include "lsst/pex/policy.h"

--- a/include/lsst/meas/algorithms/SpatialModelPsf.h
+++ b/include/lsst/meas/algorithms/SpatialModelPsf.h
@@ -31,10 +31,9 @@
  *
  * @ingroup algorithms
  */
+#include <memory>
 #include <utility>
 #include <vector>
-
-#include <memory>
 
 #include "lsst/afw.h"
 #include "lsst/pex/policy.h"

--- a/include/lsst/meas/algorithms/shapelet/Pixel.h
+++ b/include/lsst/meas/algorithms/shapelet/Pixel.h
@@ -15,7 +15,7 @@
 #ifdef __INTEL_COMPILER
 #pragma warning (disable : 1418)
 #endif
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #ifdef __INTEL_COMPILER
 #pragma warning (default : 1418)
 #endif
@@ -95,12 +95,12 @@ namespace shapelet {
     private :
 
         bool _shouldUsePool;
-        boost::shared_ptr<std::vector<Pixel> > _v1;
+        std::shared_ptr<std::vector<Pixel> > _v1;
 #ifdef PIXELLIST_USE_POOL
         typedef PoolAllocator<Pixel,PIXELLIST_BLOCK> PoolAllocPixel;
-        boost::shared_ptr<std::vector<Pixel,PoolAllocPixel> > _v2;
+        std::shared_ptr<std::vector<Pixel,PoolAllocPixel> > _v2;
 #else
-        boost::shared_ptr<std::vector<Pixel> > _v2;
+        std::shared_ptr<std::vector<Pixel> > _v2;
 #endif
 
     };

--- a/python/lsst/meas/algorithms/algorithmsLib.i
+++ b/python/lsst/meas/algorithms/algorithmsLib.i
@@ -40,7 +40,7 @@ Python bindings for meas/algorithms module
 #   include <list>
 #   include <map>
 #   include <boost/cstdint.hpp>
-#   include <boost/shared_ptr.hpp>
+#   include <memory>
 #   include "lsst/pex/logging.h"
 #   include "lsst/pex/logging/BlockTimingLog.h"
 #   include "lsst/pex/logging/DualLog.h"

--- a/python/lsst/meas/algorithms/psf.i
+++ b/python/lsst/meas/algorithms/psf.i
@@ -51,7 +51,7 @@ lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::i
 %inline %{
     PTR(lsst::meas::algorithms::PsfCandidate<TYPE>)
         cast_PsfCandidate##NAME(PTR(lsst::afw::math::SpatialCellCandidate) candidate) {
-        return boost::dynamic_pointer_cast<lsst::meas::algorithms::PsfCandidate<TYPE> >(candidate);
+        return std::dynamic_pointer_cast<lsst::meas::algorithms::PsfCandidate<TYPE> >(candidate);
     }
 %}
 //----------------------------------------------------------------------------
@@ -91,7 +91,7 @@ lsst::afw::image::MaskedImage<PIXTYPE, lsst::afw::image::MaskPixel, lsst::afw::i
 %template(fitKernelToImage) lsst::meas::algorithms::fitKernelToImage<%MASKEDIMAGE(float)>;
 
 %{
-#include "boost/shared_ptr.hpp"
+#include <memory>
 #include "lsst/meas/algorithms/SingleGaussianPsf.h"
 #include "lsst/meas/algorithms/PcaPsf.h"
 %}

--- a/src/CR.cc
+++ b/src/CR.cc
@@ -64,8 +64,8 @@ namespace detection {
  */
 class IdSpan {
 public:
-    typedef boost::shared_ptr<IdSpan> Ptr;
-    typedef boost::shared_ptr<const IdSpan> ConstPtr;
+    typedef std::shared_ptr<IdSpan> Ptr;
+    typedef std::shared_ptr<const IdSpan> ConstPtr;
 
     explicit IdSpan(int id, int y, int x0, int x1) : id(id), y(y), x0(x0), x1(x1) {}
     int id;                         /* ID for object */
@@ -138,7 +138,7 @@ bool condition_3(ImageT *estimate, double const peak,
 // A class to hold a detected pixel
 template<typename ImageT>
 struct CRPixel {
-    typedef typename boost::shared_ptr<CRPixel> Ptr;
+    typedef typename std::shared_ptr<CRPixel> Ptr;
 
     CRPixel(int _col, int _row, ImageT _val, int _id = -1) :
         id(_id), col(_col), row(_row), val(_val) {

--- a/src/CoaddBoundedField.cc
+++ b/src/CoaddBoundedField.cc
@@ -174,7 +174,7 @@ public:
                 )
             );
         }
-        return boost::make_shared<CoaddBoundedField>(
+        return std::make_shared<CoaddBoundedField>(
             afw::geom::Box2I(record1.get(keys1.bboxMin), record1.get(keys1.bboxMax)),
             archive.get<afw::image::Wcs>(record1.get(keys1.coaddWcs)),
             elements,

--- a/src/CoaddPsf.cc
+++ b/src/CoaddPsf.cc
@@ -148,7 +148,7 @@ CoaddPsf::CoaddPsf(
 ) :
     _coaddWcs(coaddWcs.clone()),
     _warpingKernelName(warpingKernelName),
-    _warpingControl(boost::make_shared<afw::math::WarpingControl>(warpingKernelName, "", cacheSize))
+    _warpingControl(std::make_shared<afw::math::WarpingControl>(warpingKernelName, "", cacheSize))
 {
     afw::table::SchemaMapper mapper(catalog.getSchema());
     mapper.addMinimalSchema(afw::table::ExposureTable::makeMinimalSchema(), true);
@@ -174,7 +174,7 @@ CoaddPsf::CoaddPsf(
 }
 
 PTR(afw::detection::Psf) CoaddPsf::clone() const {
-    return boost::make_shared<CoaddPsf>(*this);
+    return std::make_shared<CoaddPsf>(*this);
 }
 
 
@@ -256,7 +256,7 @@ PTR(afw::detection::Psf::Image) CoaddPsf::doComputeKernelImage(
     afw::geom::Box2I bbox = getOverallBBox(imgVector);
 
     // create a zero image of the right size to sum into
-    PTR(afw::detection::Psf::Image) image = boost::make_shared<afw::detection::Psf::Image>(bbox);
+    PTR(afw::detection::Psf::Image) image = std::make_shared<afw::detection::Psf::Image>(bbox);
     *image = 0.0;
     addToImage(image, imgVector, weightVector);
     *image /= weightSum;

--- a/src/DoubleGaussianPsf.cc
+++ b/src/DoubleGaussianPsf.cc
@@ -77,7 +77,7 @@ public:
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         afw::table::BaseRecord const & record = catalogs.front().front();
         LSST_ARCHIVE_ASSERT(record.getSchema() == keys.schema);
-        return boost::make_shared<DoubleGaussianPsf>(
+        return std::make_shared<DoubleGaussianPsf>(
             record.get(keys.dimensions.getX()),
             record.get(keys.dimensions.getY()),
             record.get(keys.sigma1),
@@ -118,7 +118,7 @@ DoubleGaussianPsf::DoubleGaussianPsf(int width, int height, double sigma1, doubl
 {}
     
 PTR(afw::detection::Psf) DoubleGaussianPsf::clone() const {
-    return boost::make_shared<DoubleGaussianPsf>(
+    return std::make_shared<DoubleGaussianPsf>(
         getKernel()->getWidth(),
         getKernel()->getHeight(),
         _sigma1, _sigma2, _b

--- a/src/KernelPsf.cc
+++ b/src/KernelPsf.cc
@@ -8,7 +8,7 @@ namespace lsst { namespace meas { namespace algorithms {
 PTR(afw::detection::Psf::Image) KernelPsf::doComputeKernelImage(
     afw::geom::Point2D const & position, afw::image::Color const& color
 ) const {
-    PTR(Psf::Image) im = boost::make_shared<Psf::Image>(_kernel->getDimensions());
+    PTR(Psf::Image) im = std::make_shared<Psf::Image>(_kernel->getDimensions());
     _kernel->computeImage(*im, true, position.getX(), position.getY());
     return im;
 }
@@ -19,7 +19,7 @@ KernelPsf::KernelPsf(afw::math::Kernel const & kernel, afw::geom::Point2D const 
 KernelPsf::KernelPsf(PTR(afw::math::Kernel) kernel, afw::geom::Point2D const & averagePosition) :
     ImagePsf(!kernel->isSpatiallyVarying()), _kernel(kernel), _averagePosition(averagePosition) {}
 
-PTR(afw::detection::Psf) KernelPsf::clone() const { return boost::make_shared<KernelPsf>(*this); }
+PTR(afw::detection::Psf) KernelPsf::clone() const { return std::make_shared<KernelPsf>(*this); }
 
 afw::geom::Point2D KernelPsf::getAveragePosition() const { return _averagePosition; }
 

--- a/src/PcaPsf.cc
+++ b/src/PcaPsf.cc
@@ -30,7 +30,6 @@
  * @ingroup algorithms
  */
 #include <cmath>
-
 #include <memory>
 
 #include "lsst/base.h"

--- a/src/PcaPsf.cc
+++ b/src/PcaPsf.cc
@@ -58,13 +58,13 @@ PcaPsf::PcaPsf(
 }
 
 PTR(afw::math::LinearCombinationKernel const) PcaPsf::getKernel() const {
-    return boost::static_pointer_cast<afw::math::LinearCombinationKernel const>(
+    return std::static_pointer_cast<afw::math::LinearCombinationKernel const>(
         KernelPsf::getKernel()
     );
 }
 
 PTR(afw::detection::Psf) PcaPsf::clone() const {
-    return boost::make_shared<PcaPsf>(*this);
+    return std::make_shared<PcaPsf>(*this);
 }
 
 namespace {

--- a/src/PcaPsf.cc
+++ b/src/PcaPsf.cc
@@ -31,7 +31,7 @@
  */
 #include <cmath>
 
-#include "boost/make_shared.hpp"
+#include <memory>
 
 #include "lsst/base.h"
 #include "lsst/pex/exceptions.h"

--- a/src/PsfAttributes.cc
+++ b/src/PsfAttributes.cc
@@ -303,7 +303,7 @@ double PsfAttributes::computeGaussianWidth(PsfAttributes::Method how) const {
     afwImage::MaskedImage<double> mi = afwImage::MaskedImage<double>(_psfImage);
     typedef afwImage::Exposure<double> Exposure;
     Exposure::Ptr exposure = makeExposure(mi);
-    afwDetection::Footprint::Ptr foot = boost::make_shared<afwDetection::Footprint>(exposure->getBBox(
+    afwDetection::Footprint::Ptr foot = std::make_shared<afwDetection::Footprint>(exposure->getBBox(
         afwImage::LOCAL));
 
     afwGeom::Point2D center(_psfImage->getX0() + _psfImage->getWidth()/2, 

--- a/src/PsfCandidate.cc
+++ b/src/PsfCandidate.cc
@@ -87,7 +87,7 @@ namespace {
                      )
     {
         typename afwImage::Image<LhsT>::Ptr lhs =
-            boost::make_shared<afwImage::Image<LhsT> >(rhs.getDimensions());
+            std::make_shared<afwImage::Image<LhsT> >(rhs.getDimensions());
         lhs->setXY0(rhs.getXY0());
 
         for (int y = 0; y != lhs->getHeight(); ++y) {
@@ -247,7 +247,7 @@ measAlg::PsfCandidate<PixelT>::extractImage(
 
     PTR(afwImage::Image<int>) mim = makeImageFromMask<int>(*image->getMask(), makeAndMask(detected));
     PTR(afwDetection::FootprintSet) fs =
-        boost::make_shared<afwDetection::FootprintSet>(*mim, afwDetection::Threshold(1));
+        std::make_shared<afwDetection::FootprintSet>(*mim, afwDetection::Threshold(1));
     CONST_PTR(FootprintList) feet = fs->getFootprints();
 
     if (feet->size() > 1) {
@@ -270,7 +270,7 @@ measAlg::PsfCandidate<PixelT>::extractImage(
     // Mask high pixels unconnected to the center
     if (_pixelThreshold > 0.0) {
         CONST_PTR(afwDetection::FootprintSet) fpSet =
-            boost::make_shared<afwDetection::FootprintSet>(*image,
+            std::make_shared<afwDetection::FootprintSet>(*image,
                 afwDetection::Threshold(_pixelThreshold, afwDetection::Threshold::PIXEL_STDEV));
         for (FootprintList::const_iterator fpIter = fpSet->getFootprints()->begin();
              fpIter != fpSet->getFootprints()->end(); ++fpIter) {

--- a/src/Shapelet.cc
+++ b/src/Shapelet.cc
@@ -91,7 +91,7 @@ namespace algorithms {
             }
         }
 
-        boost::shared_ptr<ShapeletCovariance>& getCovariance()
+        std::shared_ptr<ShapeletCovariance>& getCovariance()
         { return _cov; }
 
         std::complex<double> getPQ(int p, int q)
@@ -139,7 +139,7 @@ namespace algorithms {
         }
 
     private :
-        boost::shared_ptr<ShapeletCovariance> _cov;
+        std::shared_ptr<ShapeletCovariance> _cov;
     };
 
     Shapelet::Shapelet(int order, double sigma) :
@@ -182,7 +182,7 @@ namespace algorithms {
     bool Shapelet::hasCovariance() const 
     { return pImpl->getCovariance().get(); }
 
-    boost::shared_ptr<const Shapelet::ShapeletCovariance> Shapelet::getCovariance() const 
+    std::shared_ptr<const Shapelet::ShapeletCovariance> Shapelet::getCovariance() const 
     { return pImpl->getCovariance(); }
 
     void Shapelet::setSigma(double sigma)

--- a/src/ShapeletInterpolation.cc
+++ b/src/ShapeletInterpolation.cc
@@ -150,7 +150,7 @@ namespace algorithms {
         }
 
     private :
-        boost::shared_ptr<FittedPsf> _fit;
+        std::shared_ptr<FittedPsf> _fit;
         int _nStarsPerCell;
     };
 

--- a/src/ShapeletKernel.cc
+++ b/src/ShapeletKernel.cc
@@ -38,8 +38,8 @@ namespace algorithms {
     public :
         typedef lsst::afw::math::Function2<double> base;
 
-        typedef boost::shared_ptr<ShapeletKernelFunction> Ptr;
-        typedef boost::shared_ptr<const ShapeletKernelFunction> ConstPtr;
+        typedef std::shared_ptr<ShapeletKernelFunction> Ptr;
+        typedef std::shared_ptr<const ShapeletKernelFunction> ConstPtr;
 
         ShapeletKernelFunction(Shapelet::ConstPtr shapelet) :
             base(shapelet->size()+1),
@@ -80,8 +80,8 @@ namespace algorithms {
     public :
         typedef lsst::afw::math::Function2<double> base;
 
-        typedef boost::shared_ptr<ShapeletSpatialFunction> Ptr;
-        typedef boost::shared_ptr<const ShapeletSpatialFunction> ConstPtr;
+        typedef std::shared_ptr<ShapeletSpatialFunction> Ptr;
+        typedef std::shared_ptr<const ShapeletSpatialFunction> ConstPtr;
 
         ShapeletSpatialFunction(
             ShapeletInterpolation::ConstPtr interp, int i

--- a/src/SingleGaussianPsf.cc
+++ b/src/SingleGaussianPsf.cc
@@ -79,7 +79,7 @@ public:
         LSST_ARCHIVE_ASSERT(catalogs.front().size() == 1u);
         afw::table::BaseRecord const & record = catalogs.front().front();
         LSST_ARCHIVE_ASSERT(record.getSchema() == keys.schema);
-        return boost::make_shared<SingleGaussianPsf>(
+        return std::make_shared<SingleGaussianPsf>(
             record.get(keys.dimensions.getX()),
             record.get(keys.dimensions.getY()),
             record.get(keys.sigma)
@@ -98,7 +98,7 @@ PTR(afw::math::Kernel) makeSingleGaussianKernel(int width, int height, double si
                           (boost::format("sigma may not be 0: %g") % sigma).str());
     }
     afw::math::GaussianFunction1<double> sg(sigma);
-    return boost::make_shared<afw::math::SeparableKernel>(width, height, sg, sg);
+    return std::make_shared<afw::math::SeparableKernel>(width, height, sg, sg);
 }
 
 } // anonymous
@@ -108,7 +108,7 @@ SingleGaussianPsf::SingleGaussianPsf(int width, int height, double sigma) :
 {}
 
 PTR(afw::detection::Psf) SingleGaussianPsf::clone() const {
-    return boost::make_shared<SingleGaussianPsf>(
+    return std::make_shared<SingleGaussianPsf>(
         getKernel()->getWidth(), getKernel()->getHeight(),
         _sigma
     );

--- a/src/SizeMagnitudeStarSelector.cc
+++ b/src/SizeMagnitudeStarSelector.cc
@@ -93,7 +93,7 @@ SizeMagnitudeStarSelector::SizeMagnitudeStarSelector(const Policy& policy)
     params["maxrms"] = 0.05;
     params["maxrefititer"] = 5;
 
-    pImpl = boost::shared_ptr<SizeMagnitudeStarSelectorImpl>(new SizeMagnitudeStarSelectorImpl(params, policy));
+    pImpl = std::shared_ptr<SizeMagnitudeStarSelectorImpl>(new SizeMagnitudeStarSelectorImpl(params, policy));
 }
 
 double SizeMagnitudeStarSelector::calculateSourceSize(

--- a/src/SpatialModelPsf.cc
+++ b/src/SpatialModelPsf.cc
@@ -1156,7 +1156,7 @@ fitKernelToImage(
     double amp = 0.0;
     for (int i = 0; i != nKernel; ++i) {
         afwMath::Kernel::Ptr base = kernels[i];
-        afwMath::FixedKernel::Ptr k = boost::static_pointer_cast<afwMath::FixedKernel>(base);
+        afwMath::FixedKernel::Ptr k = std::static_pointer_cast<afwMath::FixedKernel>(base);
         amp += params[i] * k->getSum();
     }
 

--- a/src/WarpedPsf.cc
+++ b/src/WarpedPsf.cc
@@ -45,7 +45,7 @@ PTR(afw::detection::Psf::Image) zeroPadImage(afw::detection::Psf::Image const &i
     int nx = im.getWidth();
     int ny = im.getHeight();
 
-    PTR(afw::detection::Psf::Image) out = boost::make_shared<afw::detection::Psf::Image>(nx+2*xPad, ny+2*yPad);
+    PTR(afw::detection::Psf::Image) out = std::make_shared<afw::detection::Psf::Image>(nx+2*xPad, ny+2*yPad);
     out->setXY0(im.getX0()-xPad, im.getY0()-yPad);
 
     afw::geom::Box2I box(afw::geom::Point2I(xPad,yPad), afw::geom::Extent2I(nx,ny));
@@ -113,7 +113,7 @@ PTR(afw::detection::Psf::Image) warpAffine(
 
     // allocate output image
     PTR(afw::detection::Psf::Image) ret 
-        = boost::make_shared<afw::detection::Psf::Image>(out_xhi-out_xlo+1, out_yhi-out_ylo+1);
+        = std::make_shared<afw::detection::Psf::Image>(out_xhi-out_xlo+1, out_yhi-out_ylo+1);
     ret->setXY0(afw::geom::Point2I(out_xlo,out_ylo));
 
     // zero-pad input image
@@ -180,7 +180,7 @@ afw::geom::Point2D WarpedPsf::getAveragePosition() const {
 }
 
 PTR(afw::detection::Psf) WarpedPsf::clone() const {
-    return boost::make_shared<WarpedPsf>(_undistortedPsf->clone(), _distortion->clone(), _warpingControl);
+    return std::make_shared<WarpedPsf>(_undistortedPsf->clone(), _distortion->clone(), _warpingControl);
 }
 
 PTR(afw::detection::Psf::Image) WarpedPsf::doComputeKernelImage(

--- a/tests/testImagePsf.cc
+++ b/tests/testImagePsf.cc
@@ -59,7 +59,7 @@ public:
     }
 
     PTR(Psf) clone() const {
-        return boost::make_shared<TestGaussianPsf>(*this);
+        return std::make_shared<TestGaussianPsf>(*this);
     }
 
 private:

--- a/tests/testPsf.h
+++ b/tests/testPsf.h
@@ -79,7 +79,7 @@ public:
 
 protected:
     PTR(Image) makeImage() const {
-        PTR(Image) image = boost::make_shared<Image>(1, 1);
+        PTR(Image) image = std::make_shared<Image>(1, 1);
         *image = _value;
         return image;
     }
@@ -102,7 +102,7 @@ private:
 
 template <typename ImageT>
 PTR(TestPsf) makeTestPsf(CONST_PTR(ImageT) image, double value=1.0) {
-    return boost::make_shared<TestPsf>(image, value);
+    return std::make_shared<TestPsf>(image, value);
 }
 
 }}} // namespace test::foo::bar

--- a/tests/testPsf.h
+++ b/tests/testPsf.h
@@ -24,7 +24,7 @@
 #ifndef LSST_MEAS_ALGORITHMS_TESTS_testPsf_h_INCLUDED
 #define LSST_MEAS_ALGORITHMS_TESTS_testPsf_h_INCLUDED
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include "lsst/pex/exceptions.h"
 #include "lsst/afw/math/Kernel.h"
 #include "lsst/afw/geom/Box.h"

--- a/tests/testPsfCaching.cc
+++ b/tests/testPsfCaching.cc
@@ -47,9 +47,9 @@ BOOST_AUTO_TEST_CASE(VariablePsfCaching) {
     using namespace lsst::afw::image;
     using namespace lsst::meas::algorithms;
     std::vector<PTR(Kernel::SpatialFunction)> spatialFuncs;
-    spatialFuncs.push_back(boost::make_shared< PolynomialFunction2<double> >(1));
-    spatialFuncs.push_back(boost::make_shared< PolynomialFunction2<double> >(1));
-    spatialFuncs.push_back(boost::make_shared< PolynomialFunction2<double> >(0));
+    spatialFuncs.push_back(std::make_shared< PolynomialFunction2<double> >(1));
+    spatialFuncs.push_back(std::make_shared< PolynomialFunction2<double> >(1));
+    spatialFuncs.push_back(std::make_shared< PolynomialFunction2<double> >(0));
     spatialFuncs[0]->setParameter(0, 1.0);
     spatialFuncs[0]->setParameter(1, 0.5);
     spatialFuncs[0]->setParameter(2, 0.5);

--- a/tests/testWarpedPsf.cc
+++ b/tests/testWarpedPsf.cc
@@ -3,7 +3,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <boost/random.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include "lsst/meas/algorithms/WarpedPsf.h"
 

--- a/tests/testWarpedPsf.cc
+++ b/tests/testWarpedPsf.cc
@@ -1,9 +1,9 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE DISTORTION
-#include <boost/test/unit_test.hpp>
-
-#include <boost/random.hpp>
 #include <memory>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/random.hpp>
 
 #include "lsst/meas/algorithms/WarpedPsf.h"
 

--- a/tests/testWarpedPsf.cc
+++ b/tests/testWarpedPsf.cc
@@ -133,7 +133,7 @@ public:
     }
     
     // factory function
-    static boost::shared_ptr<ToyXYTransform> makeRandom()
+    static std::shared_ptr<ToyXYTransform> makeRandom()
     {
         double A = 0.1 * (uni_double(rng)-0.5);
         double B = 0.1 * (uni_double(rng)-0.5);
@@ -183,7 +183,7 @@ static PTR(Image<double>) fill_gaussian(double a, double b, double c, double px,
     assert(x0-px <= -width && x0-px+nx-1 >= width);
     assert(y0-py <= -width && y0-py+ny-1 >= width);
 
-    PTR(Image<double>) im = boost::make_shared<Image<double> >(nx, ny);
+    PTR(Image<double>) im = std::make_shared<Image<double> >(nx, ny);
     im->setXY0(x0, y0);
 
     double imSum = 0.0;
@@ -215,7 +215,7 @@ struct ToyPsf : public ImagePsf
     
     virtual PTR(Psf) clone() const 
     { 
-        return boost::make_shared<ToyPsf>(_A,_B,_C,_D,_E,_F); 
+        return std::make_shared<ToyPsf>(_A,_B,_C,_D,_E,_F); 
     }
 
     void evalABC(double &a, double &b, double &c, Point2D const &p) const
@@ -238,7 +238,7 @@ struct ToyPsf : public ImagePsf
     }
     
     // factory function
-    static boost::shared_ptr<ToyPsf> makeRandom()
+    static std::shared_ptr<ToyPsf> makeRandom()
     {
         double A = 0.005 * (uni_double(rng)-0.5);
         double B = 0.005 * (uni_double(rng)-0.5);
@@ -247,7 +247,7 @@ struct ToyPsf : public ImagePsf
         double E = 0.005 * (uni_double(rng)-0.5);
         double F = 0.005 * (uni_double(rng)-0.5);
 
-        return boost::make_shared<ToyPsf> (A,B,C,D,E,F);
+        return std::make_shared<ToyPsf> (A,B,C,D,E,F);
     }
 
 };
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(warpedPsf)
     PTR(XYTransform) distortion = ToyXYTransform::makeRandom();
 
     PTR(ToyPsf) unwarped_psf = ToyPsf::makeRandom();
-    PTR(WarpedPsf) warped_psf = boost::make_shared<WarpedPsf> (unwarped_psf, distortion);
+    PTR(WarpedPsf) warped_psf = std::make_shared<WarpedPsf> (unwarped_psf, distortion);
 
     Point2D p = randpt();
     Point2D q = distortion->reverseTransform(p);


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
