### PR TITLE
Allow butlers in subclasses

### DIFF
--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -171,6 +171,15 @@ class LoadReferenceObjectsTask(pipeBase.Task):
     ConfigClass = LoadReferenceObjectsConfig
     _DefaultName = "LoadReferenceObjects"
 
+    def __init__(self, butler=None, *args, **kwargs):
+        """!Construct a LoadReferenceObjectsTask
+
+        @param[in] butler  A daf.persistence.Butler object.  This allows subclasses to use the butler to
+        access reference catalog files using the stack I/O abstraction scheme.
+        """
+        pipeBase.Task.__init__(self, *args, **kwargs)
+        self.butler = butler
+
     @pipeBase.timeMethod
     def loadPixelBox(self, bbox, wcs, filterName=None, calib=None):
         """!Load reference objects that overlap a pixel-based rectangular region


### PR DESCRIPTION
Reference catalog loaders will frequently need butlers.
This allows subclasses to optionally take a butler.