### PR TITLE
make aperture correction failures optionally non-fatal

### DIFF
--- a/python/lsst/meas/algorithms/measureApCorr.py
+++ b/python/lsst/meas/algorithms/measureApCorr.py
@@ -100,6 +100,11 @@ class MeasureApCorrConfig(lsst.pex.config.Config):
         dtype=float,
         default=3.0,
     )
+    allowFailure = lsst.pex.config.ListField(
+        doc="Allow these measurement algorithms to fail without an exception",
+        dtype=str,
+        default=[],
+    )
 
     def validate(self):
         lsst.pex.config.Config.validate(self)
@@ -235,12 +240,14 @@ class MeasureApCorrTask(Task):
             # Check that we have enough data points that we have at least the minimum of degrees of
             # freedom specified in the config.
             if len(subset2) - 1 < self.config.minDegreesOfFreedom:
-                raise RuntimeError("Only %d sources for calculation of aperture correction for '%s'; "
-                                   "require at least %d."
-                                   % (len(subset2), name, self.config.minDegreesOfFreedom+1))
-                apCorrMap[fluxName] = ChebyshevBoundedField(bbox, numpy.ones((1, 1), dtype=float))
-                apCorrMap[fluxSigmaName] = ChebyshevBoundedField(bbox, numpy.zeros((1, 1), dtype=float))
-                continue
+                if name in self.config.allowFailure:
+                    self.log.warn("Unable to measure aperture correction for '%s': "
+                                  "only %d sources, but require at least %d." %
+                                  (name, len(subset2), self.config.minDegreesOfFreedom+1))
+                    continue
+                raise RuntimeError("Unable to measure aperture correction for required algorithm '%s': "
+                                   "only %d sources, but require at least %d." %
+                                   (name, len(subset2), self.config.minDegreesOfFreedom+1))
 
             # If we don't have enough data points to constrain the fit, reduce the order until we do
             ctrl = self.config.fitConfig.makeControl()

--- a/tests/testMeasureApCorr.py
+++ b/tests/testMeasureApCorr.py
@@ -140,6 +140,9 @@ class MeasureApCorrTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.t
         catalog = afwTable.SourceCatalog(self.schema)
         with self.assertRaises(RuntimeError):
             self.meas_apCorr_task.run(catalog=catalog, exposure=self.exposure)
+        # With the measurement algorithm declared as something that might fail, should not get an exception
+        self.meas_apCorr_task.config.allowFailure.append(self.apname)
+        self.meas_apCorr_task.run(catalog=catalog, exposure=self.exposure)
 
     def testSourceNotUsed(self):
         """ Check that a source outside the bounding box is flagged as not used (False)."""


### PR DESCRIPTION
Some measurement algorithms may always fail to produce a result on
certain data (e.g., seeing is too good or too bad to make the desired
measurement). The failure to measure an aperture correction for such
a measurement algorithm should not cause an exception. We now allow
certain pre-specified measurement algorithms (through the new config
parameter 'allowFailure') to fail and produce a warning rather than
an exception.