### PR TITLE
tickets/DM-8175

### DIFF
--- a/include/lsst/meas/algorithms/CoaddPsf.h
+++ b/include/lsst/meas/algorithms/CoaddPsf.h
@@ -160,6 +160,11 @@ protected:
         afw::image::Color const & color
     ) const;
 
+    virtual afw::geom::Box2I doComputeBBox(
+        afw::geom::Point2D const & position,
+        afw::image::Color const & color
+    ) const;
+
     // See afw::table::io::Persistable::getPersistenceName
     virtual std::string getPersistenceName() const;
 

--- a/include/lsst/meas/algorithms/KernelPsf.h
+++ b/include/lsst/meas/algorithms/KernelPsf.h
@@ -87,6 +87,11 @@ private:
         afw::image::Color const & color
     ) const;
 
+    virtual afw::geom::Box2I doComputeBBox(
+        afw::geom::Point2D const & position,
+        afw::image::Color const & color
+    ) const;
+
     PTR(afw::math::Kernel) _kernel;
     afw::geom::Point2D _averagePosition;
 };

--- a/include/lsst/meas/algorithms/WarpedPsf.h
+++ b/include/lsst/meas/algorithms/WarpedPsf.h
@@ -90,6 +90,11 @@ protected:
 private:
     void _init();
     CONST_PTR(afw::math::WarpingControl) _warpingControl;
+
+    virtual afw::geom::Box2I doComputeBBox(
+        afw::geom::Point2D const & position,
+        afw::image::Color const & color
+    ) const;
 };
 
 }}} // namespace lsst::meas::algorithms

--- a/src/CoaddPsf.cc
+++ b/src/CoaddPsf.cc
@@ -234,10 +234,10 @@ afw::geom::Box2I CoaddPsf::doComputeBBox(
     }
 
     afw::geom::Box2I ret;
-    for (afw::table::ExposureCatalog::const_iterator i = subcat.begin(); i != subcat.end(); ++i) {
+    for (auto const & exposureRecord : subcat) {
         PTR(afw::geom::XYTransform) xytransform(
-            new afw::image::XYTransformFromWcsPair(_coaddWcs, i->getWcs()));
-        WarpedPsf warpedPsf = WarpedPsf(i->getPsf(), xytransform, _warpingControl);
+            new afw::image::XYTransformFromWcsPair(_coaddWcs, exposureRecord.getWcs()));
+        WarpedPsf warpedPsf = WarpedPsf(exposureRecord.getPsf(), xytransform, _warpingControl);
         afw::geom::Box2I componentBBox = warpedPsf.computeBBox(ccdXY, color);
         ret.include(componentBBox);
     }
@@ -266,15 +266,15 @@ PTR(afw::detection::Psf::Image) CoaddPsf::doComputeKernelImage(
     std::vector<PTR(afw::image::Image<double>)> imgVector;
     std::vector<double> weightVector;
 
-    for (afw::table::ExposureCatalog::const_iterator i = subcat.begin(); i != subcat.end(); ++i) {
+    for (auto const & exposureRecord : subcat) {
         PTR(afw::geom::XYTransform) xytransform(
-            new afw::image::XYTransformFromWcsPair(_coaddWcs, i->getWcs())
+            new afw::image::XYTransformFromWcsPair(_coaddWcs, exposureRecord.getWcs())
         );
-        WarpedPsf warpedPsf = WarpedPsf(i->getPsf(), xytransform, _warpingControl);
+        WarpedPsf warpedPsf = WarpedPsf(exposureRecord.getPsf(), xytransform, _warpingControl);
         PTR(afw::image::Image<double>) componentImg = warpedPsf.computeKernelImage(ccdXY, color);
         imgVector.push_back(componentImg);
-        weightSum += i->get(_weightKey);
-        weightVector.push_back(i->get(_weightKey));
+        weightSum += exposureRecord.get(_weightKey);
+        weightVector.push_back(exposureRecord.get(_weightKey));
     }
 
     afw::geom::Box2I bbox = getOverallBBox(imgVector);

--- a/src/CoaddPsf.cc
+++ b/src/CoaddPsf.cc
@@ -221,6 +221,30 @@ void addToImage(
 }
 
 
+afw::geom::Box2I CoaddPsf::doComputeBBox(
+    afw::geom::Point2D const & ccdXY,
+    afw::image::Color const & color
+) const {
+    afw::table::ExposureCatalog subcat = _catalog.subsetContaining(ccdXY, *_coaddWcs, true);
+    if (subcat.empty()) {
+        throw LSST_EXCEPT(
+            pex::exceptions::InvalidParameterError,
+            (boost::format("Cannot compute BBox at point %s; no input images at that point.")
+             % ccdXY).str());
+    }
+
+    afw::geom::Box2I ret;
+    for (afw::table::ExposureCatalog::const_iterator i = subcat.begin(); i != subcat.end(); ++i) {
+        PTR(afw::geom::XYTransform) xytransform(
+            new afw::image::XYTransformFromWcsPair(_coaddWcs, i->getWcs()));
+        WarpedPsf warpedPsf = WarpedPsf(i->getPsf(), xytransform, _warpingControl);
+        afw::geom::Box2I componentBBox = warpedPsf.computeBBox(ccdXY, color);
+        ret.include(componentBBox);
+    }
+
+    return ret;
+}
+
 PTR(afw::detection::Psf::Image) CoaddPsf::doComputeKernelImage(
     afw::geom::Point2D const & ccdXY,
     afw::image::Color const & color

--- a/src/KernelPsf.cc
+++ b/src/KernelPsf.cc
@@ -13,6 +13,12 @@ PTR(afw::detection::Psf::Image) KernelPsf::doComputeKernelImage(
     return im;
 }
 
+afw::geom::Box2I KernelPsf::doComputeBBox(
+    afw::geom::Point2D const & position, afw::image::Color const& color
+) const {
+    return _kernel->getBBox();
+}
+
 KernelPsf::KernelPsf(afw::math::Kernel const & kernel, afw::geom::Point2D const & averagePosition) :
     ImagePsf(!kernel.isSpatiallyVarying()), _kernel(kernel.clone()), _averagePosition(averagePosition) {}
 

--- a/src/WarpedPsf.cc
+++ b/src/WarpedPsf.cc
@@ -119,7 +119,7 @@ PTR(afw::detection::Psf::Image) warpAffine(
     afw::math::SeparableKernel const& kernel = *wc.getWarpingKernel();
     afw::geom::Point2I const& center = kernel.getCtr();
     int const xPad = std::max(center.getX(), kernel.getWidth() - center.getX());
-    int const yPad = std::min(center.getY(), kernel.getHeight() - center.getY());
+    int const yPad = std::max(center.getY(), kernel.getHeight() - center.getY());
 
     // allocate output image
     afw::geom::Box2I bbox = computeBBoxFromTransform(im.getBBox(), t);

--- a/src/WarpedPsf.cc
+++ b/src/WarpedPsf.cc
@@ -54,6 +54,51 @@ PTR(afw::detection::Psf::Image) zeroPadImage(afw::detection::Psf::Image const &i
     return out;
 }
 
+afw::geom::Box2I computeBBoxFromTransform
+    (afw::geom::Box2I const bbox,
+     afw::geom::AffineTransform const &t
+) {
+    static const int dst_padding = 0;
+
+    afw::geom::AffineXYTransform xyTransform(t);
+
+    // This is the maximum scaling I can imagine we'd want - it's approximately what you'd
+    // get from trying to coadd 2"-pixel data (e.g. 2MASS) onto a 0.01"-pixel grid (e.g.
+    // from JWST).  Anything beyond that is probably a bug elsewhere in the code, and
+    // catching that can save us from segfaults and catastrophic memory consumption.
+    static const double maxTransformCoeff = 200.0;
+
+    if (t.getLinear().getMatrix().lpNorm<Eigen::Infinity>() > maxTransformCoeff) {
+        throw LSST_EXCEPT(
+            pex::exceptions::RangeError,
+            "Unexpectedly large transform passed to WarpedPsf");
+    }
+
+    // min/max coordinate values in input image
+    int in_xlo = bbox.getMinX();
+    int in_xhi = bbox.getMinX() + bbox.getWidth() - 1;
+    int in_ylo = bbox.getMinY();
+    int in_yhi = bbox.getMinY() + bbox.getHeight() - 1;
+
+    // corners of output image
+    afw::geom::Point2D c00 = t(afw::geom::Point2D(in_xlo, in_ylo));
+    afw::geom::Point2D c01 = t(afw::geom::Point2D(in_xlo, in_yhi));
+    afw::geom::Point2D c10 = t(afw::geom::Point2D(in_xhi, in_ylo));
+    afw::geom::Point2D c11 = t(afw::geom::Point2D(in_xhi, in_yhi));
+
+    //
+    // bounding box for output image
+    //
+    int out_xlo = floor(min4(c00.getX(), c01.getX(), c10.getX(), c11.getX())) - dst_padding;
+    int out_ylo = floor(min4(c00.getY(), c01.getY(), c10.getY(), c11.getY())) - dst_padding;
+    int out_xhi = ceil(max4(c00.getX(), c01.getX(), c10.getX(), c11.getX())) + dst_padding;
+    int out_yhi = ceil(max4(c00.getY(), c01.getY(), c10.getY(), c11.getY())) + dst_padding;
+
+    afw::geom::Box2I ret = afw::geom::Box2I(afw::geom::Point2I(out_xlo, out_ylo),
+                                            afw::geom::Extent2I(out_xhi - out_xlo + 1, out_yhi-out_ylo + 1));
+    return ret;
+}
+
 /**
  * @brief Alternate interface to afw::math::warpImage()
  * in which the caller does not need to precompute the output bounding box.
@@ -69,8 +114,6 @@ PTR(afw::detection::Psf::Image) warpAffine(
     afw::detection::Psf::Image const &im, afw::geom::AffineTransform const &t,
     afw::math::WarpingControl const &wc
 ) {
-    static const int dst_padding = 0;
-
     afw::geom::AffineXYTransform xyTransform(t);
 
     afw::math::SeparableKernel const& kernel = *wc.getWarpingKernel();
@@ -78,43 +121,9 @@ PTR(afw::detection::Psf::Image) warpAffine(
     int const xPad = std::max(center.getX(), kernel.getWidth() - center.getX());
     int const yPad = std::min(center.getY(), kernel.getHeight() - center.getY());
 
-    // This is the maximum scaling I can imagine we'd want - it's approximately what you'd
-    // get from trying to coadd 2"-pixel data (e.g. 2MASS) onto a 0.01"-pixel grid (e.g.
-    // from JWST).  Anything beyond that is probably a bug elsewhere in the code, and
-    // catching that can save us from segfaults and catastrophic memory consumption.
-    static const double maxTransformCoeff = 200.0;
-
-    if (t.getLinear().getMatrix().lpNorm<Eigen::Infinity>() > maxTransformCoeff) {
-        throw LSST_EXCEPT(
-            pex::exceptions::RangeError,
-            "Unexpectedly large transform passed to WarpedPsf"
-        );
-    }
-
-    // min/max coordinate values in input image
-    int in_xlo = im.getX0();
-    int in_xhi = im.getX0() + im.getWidth() - 1;
-    int in_ylo = im.getY0();
-    int in_yhi = im.getY0() + im.getHeight() - 1;
-
-    // corners of output image
-    afw::geom::Point2D c00 = t(afw::geom::Point2D(in_xlo,in_ylo));
-    afw::geom::Point2D c01 = t(afw::geom::Point2D(in_xlo,in_yhi));
-    afw::geom::Point2D c10 = t(afw::geom::Point2D(in_xhi,in_ylo));
-    afw::geom::Point2D c11 = t(afw::geom::Point2D(in_xhi,in_yhi));
-
-    //
-    // bounding box for output image
-    //
-    int out_xlo = floor(min4(c00.getX(),c01.getX(),c10.getX(),c11.getX())) - dst_padding;
-    int out_ylo = floor(min4(c00.getY(),c01.getY(),c10.getY(),c11.getY())) - dst_padding;
-    int out_xhi = ceil(max4(c00.getX(),c01.getX(),c10.getX(),c11.getX())) + dst_padding;
-    int out_yhi = ceil(max4(c00.getY(),c01.getY(),c10.getY(),c11.getY())) + dst_padding;
-
     // allocate output image
-    PTR(afw::detection::Psf::Image) ret 
-        = std::make_shared<afw::detection::Psf::Image>(out_xhi-out_xlo+1, out_yhi-out_ylo+1);
-    ret->setXY0(afw::geom::Point2I(out_xlo,out_ylo));
+    afw::geom::Box2I bbox = computeBBoxFromTransform(im.getBBox(), t);
+    PTR(afw::detection::Psf::Image) ret = std::make_shared<afw::detection::Psf::Image>(bbox);
 
     // zero-pad input image
     PTR(afw::detection::Psf::Image) im_padded = zeroPadImage(im, xPad, yPad);
@@ -211,6 +220,17 @@ PTR(afw::detection::Psf::Image) WarpedPsf::doComputeKernelImage(
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, "psf image has sum 0");
     }
     *ret /= normFactor;
+    return ret;
+}
+
+afw::geom::Box2I WarpedPsf::doComputeBBox(
+    afw::geom::Point2D const & position, afw::image::Color const & color
+) const {
+    afw::geom::AffineTransform t = _distortion->linearizeReverseTransform(position);
+    afw::geom::Point2D tp = t(position);
+    afw::geom::Box2I bboxUndistorted = _undistortedPsf->computeBBox(tp, color);
+    afw::geom::Box2I ret = computeBBoxFromTransform(bboxUndistorted,
+                                                    afw::geom::AffineTransform(t.invert().getLinear()));
     return ret;
 }
 

--- a/tests/testCoaddPsf.py
+++ b/tests/testCoaddPsf.py
@@ -462,6 +462,28 @@ class CoaddPsfTest(lsst.utils.tests.TestCase):
         predPos = afwGeom.Point2D(xwsum/wsum, ywsum/wsum)
         self.assertPairsNearlyEqual(predPos, mypsf.getAveragePosition())
 
+    def testBBox(self):
+        """Check that we can measure a single Gaussian's attributes."""
+
+        print("BBoxTest")
+        sigma0 = 5
+        size = [50, 60, 70, 80]
+
+        for i in range(4):
+            record = self.mycatalog.getTable().makeRecord()
+            psf = measAlg.DoubleGaussianPsf(size[i], size[i], sigma0, 1.00, 0.0)
+            record.setPsf(psf)
+            wcs = afwImage.makeWcs(self.crval, self.crpix, self.cd11, self.cd12, self.cd21, self.cd22)
+            record.setWcs(wcs)
+            record['weight'] = 1.0 * (i + 1)
+            record['id'] = i
+            bbox = afwGeom.Box2I(afwGeom.Point2I(0, 0), afwGeom.Extent2I(2000, 2000))
+            record.setBBox(bbox)
+            self.mycatalog.append(record)
+
+        mypsf = measAlg.CoaddPsf(self.mycatalog, self.wcsref, 'weight')
+
+        self.assertEqual(mypsf.computeKernelImage().getBBox(), mypsf.computeBBox())
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 

--- a/tests/testGaussianPsf.py
+++ b/tests/testGaussianPsf.py
@@ -226,6 +226,12 @@ class GaussianPsfTestCase(lsst.utils.tests.TestCase):
             self.assertEqual(psfResized.getKernel().getWidth(), lengthNew)
             self.assertEqual(psfResized.getKernel().getHeight(), lengthNew)
 
+    def testComputeBBox(self):
+        """Test that computeBBox returns same bbox as kernel
+        """
+        for psf in [self.psfDg, self.psfSg]:
+            self.assertEqual(psf.computeBBox(), psf.getKernel().getBBox())
+
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 

--- a/tests/testImagePsf.cc
+++ b/tests/testImagePsf.cc
@@ -80,6 +80,12 @@ private:
         return result;
     }
 
+    virtual Box2I doComputeBBox(
+        Point2D const & position, Color const & color
+    ) const {
+        return Box2I(Point2I(-_size/2, -_size/2), Extent2I(_size, _size));
+    }
+
     int _size;
     Quadrupole _ellipse;
 };

--- a/tests/testWarpedPsf.cc
+++ b/tests/testWarpedPsf.cc
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(warpedPsf)
 
     // TODO: improve this test; the ideal thing would be to repeat with 
     // finer resolutions and more stringent threshold
-    BOOST_CHECK(compare(*im,*im2) < 0.005);
+    BOOST_CHECK(compare(*im,*im2) < 0.006);
 
     // Check that computeBBox returns same dimensions as image
     BOOST_CHECK(warped_psf->computeBBox(p).getWidth() == nx);

--- a/tests/testWarpedPsf.cc
+++ b/tests/testWarpedPsf.cc
@@ -177,7 +177,7 @@ static PTR(Image<double>) fill_gaussian(double a, double b, double c, double px,
     double lambda = 0.5 * (a+c + sqrt((a-c)*(a-c) + b*b));
 
     // approximate size of box needed to hold kernel
-    double width = sqrt(20/lambda);
+    double width = sqrt(5./lambda);
 
     assert(lambda > 1.0e-10);
     assert(x0-px <= -width && x0-px+nx-1 >= width);
@@ -205,17 +205,17 @@ static PTR(Image<double>) fill_gaussian(double a, double b, double c, double px,
 
 struct ToyPsf : public ImagePsf
 {    
-    double _A, _B, _C, _D, _E, _F;
+    double _A, _B, _C, _D, _E, _F, _ksize;
 
-    ToyPsf(double A, double B, double C, double D, double E, double F)
-        : _A(A), _B(B), _C(C), _D(D), _E(E), _F(F) 
+    ToyPsf(double A, double B, double C, double D, double E, double F, int ksize)
+        : _A(A), _B(B), _C(C), _D(D), _E(E), _F(F), _ksize(ksize)
     { }
 
     virtual ~ToyPsf() { }
     
     virtual PTR(Psf) clone() const 
     { 
-        return std::make_shared<ToyPsf>(_A,_B,_C,_D,_E,_F); 
+        return std::make_shared<ToyPsf>(_A, _B, _C, _D, _E, _F, _ksize);
     }
 
     void evalABC(double &a, double &b, double &c, Point2D const &p) const
@@ -229,8 +229,7 @@ struct ToyPsf : public ImagePsf
     }
 
     virtual Box2I doComputeBBox(Point2D const &, Color const &) const {
-        static const int nside = 100;
-        return Box2I(Point2I(-nside, -nside), Extent2I(2*nside + 1, 2*nside + 1));
+        return Box2I(Point2I(-_ksize, -_ksize), Extent2I(2*_ksize + 1, 2*_ksize + 1));
     }
 
     virtual PTR(Image) doComputeKernelImage(Point2D const &ccdXY, Color const &) const {
@@ -241,9 +240,9 @@ struct ToyPsf : public ImagePsf
         return fill_gaussian(a, b, c, 0, 0, bbox.getWidth(), bbox.getHeight(),
                              bbox.getMinX(), bbox.getMinY());
     }
-    
+
     // factory function
-    static std::shared_ptr<ToyPsf> makeRandom()
+    static std::shared_ptr<ToyPsf> makeRandom(int ksize)
     {
         double A = 0.005 * (uni_double(rng)-0.5);
         double B = 0.005 * (uni_double(rng)-0.5);
@@ -252,7 +251,7 @@ struct ToyPsf : public ImagePsf
         double E = 0.005 * (uni_double(rng)-0.5);
         double F = 0.005 * (uni_double(rng)-0.5);
 
-        return std::make_shared<ToyPsf> (A,B,C,D,E,F);
+        return std::make_shared<ToyPsf> (A, B, C, D, E, F, ksize);
     }
 
 };
@@ -262,7 +261,7 @@ BOOST_AUTO_TEST_CASE(warpedPsf)
 {
     PTR(XYTransform) distortion = ToyXYTransform::makeRandom();
 
-    PTR(ToyPsf) unwarped_psf = ToyPsf::makeRandom();
+    PTR(ToyPsf) unwarped_psf = ToyPsf::makeRandom(100);
     PTR(WarpedPsf) warped_psf = std::make_shared<WarpedPsf> (unwarped_psf, distortion);
 
     Point2D p = randpt();
@@ -303,3 +302,42 @@ BOOST_AUTO_TEST_CASE(warpedPsf)
     BOOST_CHECK(warped_psf->computeBBox(p).getHeight() == ny);
 }
 
+// Test that WarpedPsf properly pads original Psf images before warping, so that
+// the warped image extends all the way to the edges.
+// Because afw.math.warpImage will set unfilled pixels to exactly 0 by default,
+// this test case checks that each of the 4 edges of a WarpedPsf is non-zero.
+BOOST_AUTO_TEST_CASE(warpedPsfPadding) {
+    PTR(XYTransform) distortion = ToyXYTransform::makeRandom();
+
+    // Make psf with small kernel size  so that lack of padding is more apparent
+    PTR(ToyPsf) unwarped_psf = ToyPsf::makeRandom(7);
+    PTR(WarpedPsf) warped_psf = std::make_shared<WarpedPsf> (unwarped_psf, distortion);
+    PTR(Image<double>) warpedImage = warped_psf->computeKernelImage(Point2D(-10., 150.));
+
+    // The outer columns and rows must test non-zero
+    // Tolerance should be very low, because edges of small PSFs with large BBoxes
+    // can legitimately have pixel values on order of minimum subnormal numbers (1e-323).
+    // Tolerance may be as low as zero (which has an exact representation).
+    const double zero = 0.;
+    double sumRow = 0.;
+
+    // Check first and last row
+    for (const int& y : {0, warpedImage->getHeight() - 1}) {
+        sumRow = 0.;
+        for (Image<double>::x_iterator ptr = warpedImage->row_begin(y),
+             end = warpedImage->row_end(y); ptr != end; ++ptr) {
+            sumRow += *ptr;
+        }
+        BOOST_CHECK(std::abs(sumRow) > zero);
+    }
+
+    // Check first and last column
+    for (const int& x : {0, warpedImage->getWidth() - 1}) {
+        sumRow = 0.;
+        for (Image<double>::y_iterator ptr = warpedImage->col_begin(x),
+             end = warpedImage->col_end(x); ptr != end; ++ptr) {
+            sumRow += *ptr;
+        }
+        BOOST_CHECK(std::abs(sumRow) > zero);
+    }
+}


### PR DESCRIPTION
This ticket contains computeBBox implementations for WarpedPsf, CoaddPsf, and KernelPsf (trivial).

This ticket also includes commit to reduce some of the code duplication in testCoaddPsf,  and a change to make consistent the x/y padding to the PSF image before warping it. The original author of that line (81 in WarpedPsf.cc)  agrees with the change.
