### PR TITLE
DM-8461: Wrap pipe_tasks with pybind11

### DIFF
--- a/python/lsst/meas/algorithms/algorithmsLib.py
+++ b/python/lsst/meas/algorithms/algorithmsLib.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import lsst.afw.image
 import lsst.afw.math
+from lsst.afw.image import DefectBase
 
 from ._binnedWcs import *
 from ._cr import *


### PR DESCRIPTION
Changes are to let `Defect` be imported without needing other imports first.