### PR TITLE
Tickets/DM-9120: matcherSourceSelector incorrectly uses nChild and footprints in isMultiple test.

### DIFF
--- a/python/lsst/meas/algorithms/matcherSourceSelector.py
+++ b/python/lsst/meas/algorithms/matcherSourceSelector.py
@@ -96,21 +96,16 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
         self.fluxFlagKey = schema[fluxPrefix + "flag"].asKey()
         self.fluxSigmaKey = schema[fluxPrefix + "fluxSigma"].asKey()
 
-    def _isMultiple_vector(self, sourceCat):
-        """Return True for each source that is likely multiple sources."""
-        test = (sourceCat.get(self.parentKey) != 0) | (sourceCat.get(self.nChildKey) != 0)
-        # have to currently manage footprints on a source-by-source basis.
-        for i, cat in enumerate(sourceCat):
-            footprint = cat.getFootprint()
-            test[i] |= (footprint is not None) and (len(footprint.getPeaks()) > 1)
+    def _isParent_vector(self, sourceCat):
+        """Return True for each source that is the parent source."""
+        test = (sourceCat.get(self.parentKey) != 0)
         return test
 
-    def _isMultiple(self, source):
-        """Return True if source is likely multiple sources."""
-        if ((source.get(self.parentKey) != 0) or (source.get(self.nChildKey) != 0)):
+    def _isParent(self, source):
+        """Return True if source is the parent source."""
+        if (source.get(self.parentKey) == 0):
             return True
-        footprint = source.getFootprint()
-        return footprint is not None and len(footprint.getPeaks()) > 1
+        return False
 
     def _hasCentroid_vector(self, sourceCat):
         """Return True for each source that has a valid centroid"""
@@ -147,7 +142,7 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
         - have adequate signal-to-noise
         """
         return self._hasCentroid_vector(sourceCat) \
-            & ~self._isMultiple_vector(sourceCat) \
+            & self._isParent_vector(sourceCat) \
             & self._goodSN_vector(sourceCat) \
             & ~sourceCat.get(self.fluxFlagKey)
 
@@ -163,7 +158,7 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
         - have adequate signal-to-noise
         """
         return self._hasCentroid(source) \
-            and not self._isMultiple(source) \
+            and self._isParent(source) \
             and not source.get(self.fluxFlagKey) \
             and self._goodSN(source)
 

--- a/python/lsst/meas/algorithms/matcherSourceSelector.py
+++ b/python/lsst/meas/algorithms/matcherSourceSelector.py
@@ -85,7 +85,6 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
     def _getSchemaKeys(self, schema):
         """Extract and save the necessary keys from schema with asKey."""
         self.parentKey = schema["parent"].asKey()
-        self.nChildKey = schema["deblend_nChild"].asKey()
         self.centroidXKey = schema["slot_Centroid_x"].asKey()
         self.centroidYKey = schema["slot_Centroid_y"].asKey()
         self.centroidFlagKey = schema["slot_Centroid_flag"].asKey()
@@ -98,7 +97,7 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
 
     def _isParent_vector(self, sourceCat):
         """Return True for each source that is the parent source."""
-        test = (sourceCat.get(self.parentKey) != 0)
+        test = (sourceCat.get(self.parentKey) == 0)
         return test
 
     def _isParent(self, source):

--- a/tests/testMatcherSourceSelector.py
+++ b/tests/testMatcherSourceSelector.py
@@ -89,12 +89,6 @@ class TestMatcherSourceSelector(lsst.utils.tests.TestCase):
         result = self.sourceSelector.selectSources(self.src)
         self.assertNotIn(self.src['id'][0], result.sourceCat['id'])
 
-    def testSelectSources_has_children(self):
-        add_good_source(self.src, 1)
-        self.src[0].set('deblend_nChild', 1)
-        result = self.sourceSelector.selectSources(self.src)
-        self.assertNotIn(self.src['id'][0], result.sourceCat['id'])
-
     def testSelectSources_highSN_cut(self):
         add_good_source(self.src, 1)
         add_good_source(self.src, 2)


### PR DESCRIPTION
Changed isMultiple test to isParent. Removed test requirements for the variable nChild.

This corrects a bug introduced in DM-6824 and DM-8645 that decreased the AM1 performance in validate_drp using CHFT data. This returns the code back to it's previous performance.