### PR TITLE
DM-4639: modernize afw code and reduce doxygen errors

### DIFF
--- a/include/lsst/meas/algorithms/ExposurePatch.h
+++ b/include/lsst/meas/algorithms/ExposurePatch.h
@@ -53,7 +53,7 @@ public:
                   afw::image::Wcs const& standardWcs         ///< WCS for that other exposure
         ) : _exp(exp) {
         afw::image::Wcs const& expWcs = *exp->getWcs();
-        afw::coord::Coord::ConstPtr sky = standardWcs.pixelToSky(standardCenter);
+        std::shared_ptr<afw::coord::Coord const> sky = standardWcs.pixelToSky(standardCenter);
         const_cast<CONST_PTR(afw::detection::Footprint)&>(_foot) = standardFoot.transform(standardWcs, expWcs,
                                                                                           exp->getBBox());
         const_cast<afw::geom::Point2D&>(_center) = expWcs.skyToPixel(*sky);

--- a/include/lsst/meas/algorithms/SpatialModelPsf.h
+++ b/include/lsst/meas/algorithms/SpatialModelPsf.h
@@ -47,7 +47,7 @@ namespace meas {
 namespace algorithms {
     
 template<typename PixelT>
-std::pair<lsst::afw::math::LinearCombinationKernel::Ptr, std::vector<double> >
+std::pair<std::shared_ptr<lsst::afw::math::LinearCombinationKernel>, std::vector<double> >
 createKernelFromPsfCandidates(lsst::afw::math::SpatialCellSet const& psfCells,
                               lsst::afw::geom::Extent2I const& dims,
                               lsst::afw::geom::Point2I const& xy0,
@@ -88,7 +88,7 @@ fitKernelParamsToImage(lsst::afw::math::LinearCombinationKernel const& kernel,
                        Image const& image, lsst::afw::geom::Point2D const& pos);
 
 template<typename Image>
-std::pair<lsst::afw::math::Kernel::Ptr, std::pair<double, double> >
+std::pair<std::shared_ptr<lsst::afw::math::Kernel>, std::pair<double, double> >
 fitKernelToImage(lsst::afw::math::LinearCombinationKernel const& kernel,
                  Image const& image, lsst::afw::geom::Point2D const& pos);
 

--- a/src/CR.cc
+++ b/src/CR.cc
@@ -364,7 +364,7 @@ findCosmicRays(MaskedImageT &mimage,      ///< Image to search
  *
  * Realise PSF at center of image
  */
-    lsst::afw::math::Kernel::ConstPtr kernel = psf.getLocalKernel();
+    std::shared_ptr<lsst::afw::math::Kernel const> kernel = psf.getLocalKernel();
     if (!kernel) {
         throw LSST_EXCEPT(pexExcept::NotFoundError, "Psf is unable to return a kernel");
     }

--- a/src/ImagePca.cc
+++ b/src/ImagePca.cc
@@ -81,7 +81,7 @@ void PsfImagePca<ImageT>::analyze()
                 // Use the median of the edge pixels
 
                 // If ImageT is a MaskedImage, unpack the Image
-                typename afw::image::GetImage<ImageT>::type::Ptr eImageIm =
+                std::shared_ptr<typename afw::image::GetImage<ImageT>::type> eImageIm =
                     afw::image::GetImage<ImageT>::getImage(eImage);
 
                 int const nEdge = width*height - (width - 2*_border)*(height - 2*_border);

--- a/src/Interp.cc
+++ b/src/Interp.cc
@@ -2043,8 +2043,8 @@ static void do_defects(std::vector<Defect::Ptr> const & badList, // list of bad 
 
 namespace {
     template<typename T>
-    struct Sort_ByX0 : public std::binary_function<typename T::Ptr const, typename T::Ptr const, bool> {
-        bool operator() (typename T::Ptr const a, typename T::Ptr const b) const {
+    struct Sort_ByX0 : public std::binary_function<std::shared_ptr<T> const, std::shared_ptr<T> const, bool> {
+        bool operator() (std::shared_ptr<T> const a, std::shared_ptr<T> const b) const {
             return a->getX0() < b->getX0();
         }
     };

--- a/src/PsfAttributes.cc
+++ b/src/PsfAttributes.cc
@@ -304,7 +304,7 @@ double PsfAttributes::computeGaussianWidth(PsfAttributes::Method how) const {
      */
     afwImage::MaskedImage<double> mi = afwImage::MaskedImage<double>(_psfImage);
     typedef afwImage::Exposure<double> Exposure;
-    Exposure::Ptr exposure = makeExposure(mi);
+    std::shared_ptr<Exposure> exposure = makeExposure(mi);
     auto foot = std::make_shared<afwDetection::Footprint>(std::make_shared<afwGeom::SpanSet>(exposure->getBBox(
         afwImage::LOCAL)));
 

--- a/src/PsfCandidate.cc
+++ b/src/PsfCandidate.cc
@@ -81,12 +81,12 @@ namespace {
      * Return an Image initialized from a Mask (possibly modified by func)
      */
     template<typename LhsT, typename RhsT>
-    typename afwImage::Image<LhsT>::Ptr
+    std::shared_ptr<afwImage::Image<LhsT>>
     makeImageFromMask(afwImage::Mask<RhsT> const& rhs,     ///< mask to process
                       afwImage::pixelOp1<RhsT> const& func=noop<RhsT>() ///< functor to call
                      )
     {
-        typename afwImage::Image<LhsT>::Ptr lhs =
+        std::shared_ptr<afwImage::Image<LhsT>> lhs =
             std::make_shared<afwImage::Image<LhsT> >(rhs.getDimensions());
         lhs->setXY0(rhs.getXY0());
 

--- a/tests/testPsfAttributes.cc
+++ b/tests/testPsfAttributes.cc
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(PsfAttributes) {
     int xwid = static_cast<int>(12*sigma0);
     int ywid = xwid;
 
-    afwDetection::Psf::Ptr psf(new measAlg::SingleGaussianPsf(xwid, ywid, sigma0));
+    std::shared_ptr<afwDetection::Psf> psf(new measAlg::SingleGaussianPsf(xwid, ywid, sigma0));
 
     measAlg::PsfAttributes psfAttrib(psf, xwid/2.0, ywid/2.0);
     double sigma = psfAttrib.computeGaussianWidth(measAlg::PsfAttributes::ADAPTIVE_MOMENT);


### PR DESCRIPTION
[DM-4639](https://jira.lsstcorp.org/browse/DM-4639) requires that `afw` components no longer have type members `Ptr` and `ConstPtr` representing shared pointers to those types. This is a breaking API change that requires changes to downstream code.

For clarity, no unnecessary changes changes were made to this package, not even a `clang-format` pass.