### PR TITLE
DM-11023: CoaddPsf: add more exception info

### DIFF
--- a/src/CoaddPsf.cc
+++ b/src/CoaddPsf.cc
@@ -274,8 +274,15 @@ PTR(afw::detection::Psf::Image) CoaddPsf::doComputeKernelImage(
         PTR(afw::geom::XYTransform) xytransform(
             new afw::image::XYTransformFromWcsPair(_coaddWcs, exposureRecord.getWcs())
         );
-        WarpedPsf warpedPsf = WarpedPsf(exposureRecord.getPsf(), xytransform, _warpingControl);
-        PTR(afw::image::Image<double>) componentImg = warpedPsf.computeKernelImage(ccdXY, color);
+        PTR(afw::image::Image<double>) componentImg;
+        try {
+            WarpedPsf warpedPsf = WarpedPsf(exposureRecord.getPsf(), xytransform, _warpingControl);
+            componentImg = warpedPsf.computeKernelImage(ccdXY, color);
+        } catch (pex::exceptions::RangeError & exc) {
+            LSST_EXCEPT_ADD(exc, (boost::format("Computing WarpedPsf kernel image for id=%d") %
+                                  exposureRecord.getId()).str());
+            throw exc;
+        }
         imgVector.push_back(componentImg);
         weightSum += exposureRecord.get(_weightKey);
         weightVector.push_back(exposureRecord.get(_weightKey));


### PR DESCRIPTION
A common problem when calling CoaddPsf.computePsfImage() is that
WarpedPsf.computeBBoxFromTransform throws a RangeError stating
'Unexpectedly large transform passed to WarpedPsf'. This is
usually because the astrometry for an input is poor, but it would
be nice to identify *which* input: so add the exposure ID to the
exception message.