### PR TITLE
DM-11338: CoaddPsf: add control class

### DIFF
--- a/python/lsst/meas/algorithms/SConscript
+++ b/python/lsst/meas/algorithms/SConscript
@@ -3,7 +3,7 @@ from lsst.sconsUtils import scripts
 scripts.BasicSConscript.pybind11(["binnedWcs",
                                   "cr",
                                   "coaddBoundedField",
-                                  "coaddPsf",
+                                  "coaddPsf/coaddPsf",
                                   "doubleGaussianPsf",
                                   "imagePsf",
                                   "interp",

--- a/python/lsst/meas/algorithms/__init__.py
+++ b/python/lsst/meas/algorithms/__init__.py
@@ -67,6 +67,3 @@ from .version import *
 
 import lsst.utils
 
-for name in dict(globals()):
-    if name.endswith("_swigregister"):
-        del globals()[name]

--- a/python/lsst/meas/algorithms/coaddPsf/__init__.py
+++ b/python/lsst/meas/algorithms/coaddPsf/__init__.py
@@ -1,0 +1,26 @@
+# 
+# LSST Data Management System
+#
+# Copyright 2008-2017  AURA/LSST.
+# 
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the LSST License Statement and 
+# the GNU General Public License along with this program.  If not, 
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import absolute_import
+
+from .coaddPsf import *
+from .coaddPsfContinued import *

--- a/python/lsst/meas/algorithms/coaddPsf/coaddPsf.cc
+++ b/python/lsst/meas/algorithms/coaddPsf/coaddPsf.cc
@@ -23,6 +23,7 @@
 
 #include "lsst/afw/table/io/python.h"
 #include "lsst/meas/algorithms/CoaddPsf.h"
+#include "lsst/pex/config/python.h"  // for LSST_DECLARE_CONTROL_FIELD
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -34,6 +35,13 @@ namespace algorithms {
 PYBIND11_PLUGIN(coaddPsf) {
     py::module mod("coaddPsf");
 
+    /* CoaddPsfControl */
+    py::class_<CoaddPsfControl, std::shared_ptr<CoaddPsfControl>> clsControl(mod, "CoaddPsfControl");
+    clsControl.def(py::init<std::string, int>(), "warpingKernelName"_a="lanczos3", "cacheSize"_a=10000);
+    LSST_DECLARE_CONTROL_FIELD(clsControl, CoaddPsfControl, warpingKernelName);
+    LSST_DECLARE_CONTROL_FIELD(clsControl, CoaddPsfControl, cacheSize);
+
+    /* CoaddPsf */
     afw::table::io::python::declarePersistableFacade<CoaddPsf>(mod, "CoaddPsf");
 
     py::class_<CoaddPsf, std::shared_ptr<CoaddPsf>, afw::table::io::PersistableFacade<CoaddPsf>, ImagePsf>
@@ -44,6 +52,9 @@ PYBIND11_PLUGIN(coaddPsf) {
                              std::string const &, std::string const &, int>(),
                     "catalog"_a, "coaddWcs"_a, "weightFieldName"_a = "weight",
                     "warpingKernelName"_a = "lanczos3", "cacheSize"_a = 10000);
+    clsCoaddPsf.def(py::init<afw::table::ExposureCatalog const &, afw::image::Wcs const &,
+                             CoaddPsfControl const &, std::string const &>(),
+                    "catalog"_a, "coaddWcs"_a, "ctrl"_a, "weightFieldName"_a = "weight");
 
     /* Members */
     clsCoaddPsf.def("clone", &CoaddPsf::clone);

--- a/python/lsst/meas/algorithms/coaddPsf/coaddPsfContinued.py
+++ b/python/lsst/meas/algorithms/coaddPsf/coaddPsfContinued.py
@@ -1,0 +1,31 @@
+# 
+# LSST Data Management System
+#
+# Copyright 2008-2017  AURA/LSST.
+# 
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the LSST License Statement and 
+# the GNU General Public License along with this program.  If not, 
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from __future__ import absolute_import
+
+__all__ = ["CoaddPsfConfig"]
+
+from lsst.utils import continueClass
+from .coaddPsf import CoaddPsfControl
+from lsst.pex.config import makeConfigClass
+
+makeConfigClass(CoaddPsfControl, "CoaddPsfConfig")


### PR DESCRIPTION
This allows simple configuration of CoaddPsf from python.