### PR TITLE
DM-11776: suppress numpy NAN warnings

### DIFF
--- a/python/lsst/meas/algorithms/astrometrySourceSelector.py
+++ b/python/lsst/meas/algorithms/astrometrySourceSelector.py
@@ -141,7 +141,8 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
         if self.config.minSnr <= 0:
             return True
         else:
-            return sourceCat.get(self.fluxKey)/sourceCat.get(self.fluxSigmaKey) > self.config.minSnr
+            with np.errstate(invalid="ignore"):  # suppress NAN warnings
+                return sourceCat.get(self.fluxKey)/sourceCat.get(self.fluxSigmaKey) > self.config.minSnr
 
     def _goodSN(self, source):
         """Return True if source has Signal/Noise > config.minSnr."""

--- a/python/lsst/meas/algorithms/matcherSourceSelector.py
+++ b/python/lsst/meas/algorithms/matcherSourceSelector.py
@@ -122,7 +122,8 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
         if self.config.minSnr <= 0:
             return True
         else:
-            return sourceCat.get(self.fluxKey)/sourceCat.get(self.fluxSigmaKey) > self.config.minSnr
+            with np.errstate(invalid="ignore"):  # suppress NAN warnings
+                return sourceCat.get(self.fluxKey)/sourceCat.get(self.fluxSigmaKey) > self.config.minSnr
 
     def _goodSN(self, source):
         """Return True if source has Signal/Noise > config.minSnr."""

--- a/python/lsst/meas/algorithms/measureApCorr.py
+++ b/python/lsst/meas/algorithms/measureApCorr.py
@@ -284,7 +284,8 @@ class MeasureApCorrTask(Task):
 
                 # Clip bad data points
                 apCorrDiffLim = self.config.numSigmaClip * apCorrErr
-                keep = numpy.fabs(apCorrDiffs) <= apCorrDiffLim
+                with numpy.errstate(invalid="ignore"):  # suppress NAN warning
+                    keep = numpy.fabs(apCorrDiffs) <= apCorrDiffLim
                 x = x[keep]
                 y = y[keep]
                 apCorrData = apCorrData[keep]

--- a/python/lsst/meas/algorithms/objectSizeStarSelector.py
+++ b/python/lsst/meas/algorithms/objectSizeStarSelector.py
@@ -391,15 +391,15 @@ class ObjectSizeStarSelectorTask(BaseStarSelectorTask):
             xx[i], xy[i], yy[i] = Ixx, Ixy, Iyy
 
         width = numpy.sqrt(0.5*(xx + yy))
-
-        bad = reduce(lambda x, y: numpy.logical_or(x, sourceCat.get(y)), self.config.badFlags, False)
-        bad = numpy.logical_or(bad, flux < self.config.fluxMin)
-        bad = numpy.logical_or(bad, numpy.logical_not(numpy.isfinite(width)))
-        bad = numpy.logical_or(bad, numpy.logical_not(numpy.isfinite(flux)))
-        bad = numpy.logical_or(bad, width < self.config.widthMin)
-        bad = numpy.logical_or(bad, width > self.config.widthMax)
-        if self.config.fluxMax > 0:
-            bad = numpy.logical_or(bad, flux > self.config.fluxMax)
+        with numpy.errstate(invalid="ignore"):  # suppress NAN warnings
+            bad = reduce(lambda x, y: numpy.logical_or(x, sourceCat.get(y)), self.config.badFlags, False)
+            bad = numpy.logical_or(bad, flux < self.config.fluxMin)
+            bad = numpy.logical_or(bad, numpy.logical_not(numpy.isfinite(width)))
+            bad = numpy.logical_or(bad, numpy.logical_not(numpy.isfinite(flux)))
+            bad = numpy.logical_or(bad, width < self.config.widthMin)
+            bad = numpy.logical_or(bad, width > self.config.widthMax)
+            if self.config.fluxMax > 0:
+                bad = numpy.logical_or(bad, flux > self.config.fluxMax)
         good = numpy.logical_not(bad)
 
         if not numpy.any(good):

--- a/python/lsst/meas/algorithms/sourceSelector.py
+++ b/python/lsst/meas/algorithms/sourceSelector.py
@@ -138,10 +138,11 @@ class BaseLimit(pexConfig.Config):
             (True means selected).
         """
         selected = np.ones(len(values), dtype=bool)
-        if self.minimum is not None:
-            selected &= values > self.minimum
-        if self.maximum is not None:
-            selected &= values < self.maximum
+        with np.errstate(invalid="ignore"):  # suppress NAN warnings
+            if self.minimum is not None:
+                selected &= values > self.minimum
+            if self.maximum is not None:
+                selected &= values < self.maximum
         return selected
 
 


### PR DESCRIPTION
/software/lsstsw/stack/Linux64/meas_algorithms/13.0-18-gc4ad422+4/python/lsst/meas/algorithms/objectSizeStarSelector.py:400: RuntimeWarning: invalid value encountered in less
  bad = numpy.logical_or(bad, width < self.config.widthMin)
/software/lsstsw/stack/Linux64/meas_algorithms/13.0-18-gc4ad422+4/python/lsst/meas/algorithms/objectSizeStarSelector.py:401: RuntimeWarning: invalid value encountered in greater
  bad = numpy.logical_or(bad, width > self.config.widthMax)
/software/lsstsw/stack/Linux64/meas_algorithms/13.0-18-gc4ad422+4/python/lsst/meas/algorithms/matcherSourceSelector.py:126: RuntimeWarning: invalid value encountered in greater
  return sourceCat.get(self.fluxKey)/sourceCat.get(self.fluxSigmaKey) > self.config.minSnr