### PR TITLE
DM-13617: detection: fix restoration of tempWideBackground

### DIFF
--- a/python/lsst/meas/algorithms/detection.py
+++ b/python/lsst/meas/algorithms/detection.py
@@ -899,7 +899,7 @@ into your debug.py file and run measAlgTasks.py with the \c --debug flag.
         doTempWideBackground = self.config.doTempWideBackground
         if doTempWideBackground:
             self.log.info("Applying temporary wide background subtraction")
-            original = exposure.maskedImage.image.array[:]
+            original = exposure.maskedImage.image.array[:].copy()
             self.tempWideBackground.run(exposure).background
             # Remove NO_DATA regions (e.g., edge of the field-of-view); these can cause detections after
             # subtraction because of extrapolation of the background model into areas with no constraints.


### PR DESCRIPTION
We weren't restoring the original image because we didn't have a copy
of it.