### PR TITLE
DM-9937: Add noexcept specifiers to applicable methods in afw

### DIFF
--- a/include/lsst/meas/algorithms/CoaddBoundedField.h
+++ b/include/lsst/meas/algorithms/CoaddBoundedField.h
@@ -83,7 +83,7 @@ public:
     /**
      *  @brief Return true if the CoaddBoundedField persistable (always true).
      */
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     // Factory used to read CoaddPsf from an InputArchive; defined only in the source file.
     class Factory;

--- a/include/lsst/meas/algorithms/CoaddPsf.h
+++ b/include/lsst/meas/algorithms/CoaddPsf.h
@@ -176,7 +176,7 @@ public:
      *  And it's simpler and much faster if we just always return true, rather than loop over the
      *  elements and check each one.
      */
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
     // Factory used to read CoaddPsf from an InputArchive; defined only in the source file.
     class Factory;

--- a/include/lsst/meas/algorithms/DoubleGaussianPsf.h
+++ b/include/lsst/meas/algorithms/DoubleGaussianPsf.h
@@ -63,7 +63,7 @@ public:
     double getB() const { return _b; }
 
     /// Whether this Psf is persistable (always true for DoubleGaussianPsf).
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/include/lsst/meas/algorithms/KernelPsf.h
+++ b/include/lsst/meas/algorithms/KernelPsf.h
@@ -61,7 +61,7 @@ public:
     virtual PTR(afw::detection::Psf) resized(int width, int height) const;
 
     /// Whether this object is persistable; just delegates to the kernel.
-    virtual bool isPersistable() const;
+    virtual bool isPersistable() const noexcept override;
 
 protected:
     /// Construct a KernelPsf with the given kernel; it should not be modified afterwards.

--- a/include/lsst/meas/algorithms/SingleGaussianPsf.h
+++ b/include/lsst/meas/algorithms/SingleGaussianPsf.h
@@ -59,7 +59,7 @@ public:
     double getSigma() const { return _sigma; }
 
     /// Whether the Psf is persistable; always true.
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
     virtual std::string getPersistenceName() const;

--- a/src/CoaddTransmissionCurve.cc
+++ b/src/CoaddTransmissionCurve.cc
@@ -132,7 +132,7 @@ public:
         out.deep() /= weightSum;
     }
 
-    bool isPersistable() const override {
+    bool isPersistable() const noexcept override {
         for (auto const& input : _inputs) {
             if (!input.transmission->isPersistable()) {
                 return false;

--- a/src/KernelPsf.cc
+++ b/src/KernelPsf.cc
@@ -54,7 +54,7 @@ KernelPsfPersistenceHelper::KernelPsfPersistenceHelper()
     schema.getCitizen().markPersistent();
 }
 
-bool KernelPsf::isPersistable() const { return _kernel->isPersistable(); }
+bool KernelPsf::isPersistable() const noexcept override { return _kernel->isPersistable(); }
 
 std::string KernelPsf::getPersistenceName() const { return "KernelPsf"; }
 


### PR DESCRIPTION
lsst/afw#366 adds a `noexcept` specifier to `afw::table::io::Persistence::isPersistable`. This PR adds a `noexcept` specifier to all methods that override `Persistence::isPersistable`, as required by type safety.