### PR TITLE
DM-15043: Broken build in meas_algorithms

### DIFF
--- a/src/KernelPsf.cc
+++ b/src/KernelPsf.cc
@@ -54,7 +54,7 @@ KernelPsfPersistenceHelper::KernelPsfPersistenceHelper()
     schema.getCitizen().markPersistent();
 }
 
-bool KernelPsf::isPersistable() const noexcept override { return _kernel->isPersistable(); }
+bool KernelPsf::isPersistable() const noexcept { return _kernel->isPersistable(); }
 
 std::string KernelPsf::getPersistenceName() const { return "KernelPsf"; }
 


### PR DESCRIPTION
This PR fixes an invalid use of `override` added in #128 (`override` can only be used for method declarations, not definitions).