### PR TITLE
DM-17399: Restore broken test.

### DIFF
--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -307,6 +307,7 @@ class FindAndMeasureTestCase(lsst.utils.tests.TestCase):
         self.exposure.setPsf(self.psf)
         task.run(measCat, self.exposure)
 
+        self.assertGreater(len(measCat), 0)
         for source in measCat:
 
             if source.get("base_PixelFlags_flag_edge"):


### PR DESCRIPTION
This test was disabled on DM-1608, when we inadvertently dropped the call to
FootprintSet.makeSources(). Here, we restore that, and fix up the rest of the
code to run successfully.