### PR TITLE
DM-17413: Don't do the first tweakBackground() during DynamicDetection.

### DIFF
--- a/python/lsst/meas/algorithms/dynamicDetection.py
+++ b/python/lsst/meas/algorithms/dynamicDetection.py
@@ -210,8 +210,6 @@ class DynamicDetectionTask(SourceDetectionTask):
             factor = threshResults.multiplicative
             self.log.info("Modifying configured detection threshold by factor %f to %f",
                           factor, factor*self.config.thresholdValue)
-            if self.config.doBackgroundTweak:
-                self.tweakBackground(exposure, threshResults.additive)
 
             # Blow away preliminary (low threshold) detection mask
             self.clearMask(maskedImage.mask)


### PR DESCRIPTION
tweakBackground() is called twice during DynamicDetection, but the first
call does not affect footprint detection because it only tweaks the
original image [A] and forgets to modify the PSF-convoluted image [B] on
which the detection process runs. In peak detection, a small-scale
background is estimated from [A] and subtracted from [B]. It is wrong
because [A] and [B] has different biases due to the first call to
tweakBackground().

It is better to cease to call tweakBackground() here than to tweak [B]
together with [A]. The background estimate at this point is wrong because
detection masks have been shrinked by tempWideBackground.