### PR TITLE
DM-20763: Actually apply flux field aliases in Gen3 code path.

### DIFF
--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -421,7 +421,7 @@ class ReferenceObjectLoader:
         expandedCat = self.remapReferenceCatalogSchema(refCat, position=True)
 
         # Add flux aliases
-        self.addFluxAliases(expandedCat, self.config.defaultFilter, self.config.filterMap)
+        expandedCat = self.addFluxAliases(expandedCat, self.config.defaultFilter, self.config.filterMap)
 
         # Ensure that the returned reference catalog is continuous in memory
         if not expandedCat.isContiguous():
@@ -608,7 +608,6 @@ class ReferenceObjectLoader:
         refCat = ReferenceObjectLoader.remapReferenceCatalogSchema(refCat,
                                                                    filterNameList=filterReferenceMap.keys())
         aliasMap = refCat.schema.getAliasMap()
-
         if filterReferenceMap is None:
             filterReferenceMap = {}
         for filterName, refFilterName in itertools.chain([(None, defaultFilter)],


### PR DESCRIPTION
Prior to this change, we were applying them to a temporary catalog we dropped on the floor, because we were expecting a function to operate in-place rather than return a result.