### PR TITLE
DM-27045: Add normalize_on_init to readText and readFits

### DIFF
--- a/python/lsst/meas/algorithms/defects.py
+++ b/python/lsst/meas/algorithms/defects.py
@@ -530,7 +530,7 @@ class Defects(collections.abc.MutableSequence):
         return values[:n]
 
     @classmethod
-    def fromTable(cls, table):
+    def fromTable(cls, table, normalize_on_init=True):
         """Construct a `Defects` from the contents of a
         `~lsst.afw.table.BaseCatalog`.
 
@@ -538,6 +538,11 @@ class Defects(collections.abc.MutableSequence):
         ----------
         table : `lsst.afw.table.BaseCatalog`
             Table with one row per defect.
+        normalize_on_init : `bool`, optional
+            If `True`, normalization is applied to the defects listed in the
+            table to remove duplicates, eliminate overlaps, etc. Otherwise
+            the defects in the returned object exactly match those in the
+            table.
 
         Returns
         -------
@@ -633,7 +638,7 @@ class Defects(collections.abc.MutableSequence):
 
             defectList.append(box)
 
-        defects = cls(defectList)
+        defects = cls(defectList, normalize_on_init=normalize_on_init)
         defects.setMetadata(table.getMetadata())
 
         # Once read, the schema headers are irrelevant
@@ -645,14 +650,19 @@ class Defects(collections.abc.MutableSequence):
         return defects
 
     @classmethod
-    def readFits(cls, *args):
+    def readFits(cls, *args, normalize_on_init=False):
         """Read defect list from FITS table.
 
         Parameters
         ----------
         *args
             Arguments to be forwarded to
-            `lsst.afw.table.BaseCatalog.writeFits`.
+            `lsst.afw.table.BaseCatalog.readFits`.
+        normalize_on_init : `bool`, optional
+            If `True`, normalization is applied to the defects read fom the
+            file to remove duplicates, eliminate overlaps, etc. Otherwise
+            the defects in the returned object exactly match those in the
+            file.
 
         Returns
         -------
@@ -660,16 +670,21 @@ class Defects(collections.abc.MutableSequence):
             Defects read from a FITS table.
         """
         table = lsst.afw.table.BaseCatalog.readFits(*args)
-        return cls.fromTable(table)
+        return cls.fromTable(table, normalize_on_init=normalize_on_init)
 
     @classmethod
-    def readText(cls, filename):
+    def readText(cls, filename, normalize_on_init=False):
         """Read defect list from standard format text table file.
 
         Parameters
         ----------
         filename : `str`
             Name of the file containing the defects definitions.
+        normalize_on_init : `bool`, optional
+            If `True`, normalization is applied to the defects read fom the
+            file to remove duplicates, eliminate overlaps, etc. Otherwise
+            the defects in the returned object exactly match those in the
+            file.
 
         Returns
         -------
@@ -704,7 +719,7 @@ class Defects(collections.abc.MutableSequence):
         afwTable.setMetadata(metadata)
 
         # Extract defect information from the table itself
-        return cls.fromTable(afwTable)
+        return cls.fromTable(afwTable, normalize_on_init=normalize_on_init)
 
     @classmethod
     def readLsstDefectsFile(cls, filename):

--- a/python/lsst/meas/algorithms/defects.py
+++ b/python/lsst/meas/algorithms/defects.py
@@ -722,13 +722,18 @@ class Defects(collections.abc.MutableSequence):
         return cls.fromTable(afwTable, normalize_on_init=normalize_on_init)
 
     @classmethod
-    def readLsstDefectsFile(cls, filename):
+    def readLsstDefectsFile(cls, filename, normalize_on_init=False):
         """Read defects information from a legacy LSST format text file.
 
         Parameters
         ----------
         filename : `str`
             Name of text file containing the defect information.
+        normalize_on_init : `bool`, optional
+            If `True`, normalization is applied to the defects read fom the
+            file to remove duplicates, eliminate overlaps, etc. Otherwise
+            the defects in the returned object exactly match those in the
+            file.
 
         Returns
         -------
@@ -760,9 +765,11 @@ class Defects(collections.abc.MutableSequence):
                                   dtype=[("x0", "int"), ("y0", "int"),
                                          ("x_extent", "int"), ("y_extent", "int")])
 
-        return cls(lsst.geom.Box2I(lsst.geom.Point2I(row["x0"], row["y0"]),
+        defects = (lsst.geom.Box2I(lsst.geom.Point2I(row["x0"], row["y0"]),
                                    lsst.geom.Extent2I(row["x_extent"], row["y_extent"]))
                    for row in defect_array)
+
+        return cls(defects, normalize_on_init=normalize_on_init)
 
     @classmethod
     def fromFootprintList(cls, fpList):

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -140,7 +140,8 @@ class DefectsTestCase(lsst.utils.tests.TestCase):
         # The two coincident points are combined on read, so we end up with two defects.
 
         with self.assertLogs():
-            defects = algorithms.Defects.readFits(os.path.join(TESTDIR, "data", "fits_region.fits"))
+            defects = algorithms.Defects.readFits(os.path.join(TESTDIR, "data", "fits_region.fits"),
+                                                  normalize_on_init=True)
 
         self.assertEqual(len(defects), 2)
 

--- a/tests/test_interp.py
+++ b/tests/test_interp.py
@@ -162,7 +162,7 @@ class DefectsTestCase(lsst.utils.tests.TestCase):
 10 10 10 10
 """, file=fh)
 
-            defects = algorithms.Defects.readLsstDefectsFile(tmpFile)
+            defects = algorithms.Defects.readLsstDefectsFile(tmpFile, normalize_on_init=True)
 
         # Although there are 9 defects listed above, we record 11 after
         # normalization. This is due to non-optimal behaviour in


### PR DESCRIPTION
This allows us to control whether the defects are normalized when being read from an external source. We default to False.