### PR TITLE
DM-27364: Initialize counter before forking for python 3.8 support on mac

### DIFF
--- a/python/lsst/meas/algorithms/ingestIndexManager.py
+++ b/python/lsst/meas/algorithms/ingestIndexManager.py
@@ -36,9 +36,9 @@ from lsst.afw.image import fluxErrFromABMagErr
 
 # global shared counter to keep track of source ids
 # (multiprocess sharing is most easily done with a global)
-COUNTER = 0
+COUNTER = multiprocessing.Value('i', 0)
 # global shared counter to keep track of number of files processed.
-FILE_PROGRESS = 0
+FILE_PROGRESS = multiprocessing.Value('i', 0)
 
 
 class IngestIndexManager:
@@ -97,8 +97,8 @@ class IngestIndexManager:
         self.nInputFiles = len(inputFiles)
 
         with multiprocessing.Manager() as manager:
-            COUNTER = multiprocessing.Value('i', 0)
-            FILE_PROGRESS = multiprocessing.Value('i', 0)
+            COUNTER.value = 0
+            FILE_PROGRESS.value = 0
             fileLocks = manager.dict()
             self.log.info("Creating %s file locks.", self.htmRange[1] - self.htmRange[0])
             for i in range(self.htmRange[0], self.htmRange[1]):

--- a/python/lsst/meas/algorithms/ingestIndexManager.py
+++ b/python/lsst/meas/algorithms/ingestIndexManager.py
@@ -21,6 +21,7 @@
 
 __all__ = ["IngestIndexManager", "IngestGaiaManager"]
 
+from ctypes import c_int
 import os.path
 import itertools
 import multiprocessing
@@ -36,9 +37,9 @@ from lsst.afw.image import fluxErrFromABMagErr
 
 # global shared counter to keep track of source ids
 # (multiprocess sharing is most easily done with a global)
-COUNTER = multiprocessing.Value('i', 0)
+COUNTER = multiprocessing.Value(c_int, 0)
 # global shared counter to keep track of number of files processed.
-FILE_PROGRESS = multiprocessing.Value('i', 0)
+FILE_PROGRESS = multiprocessing.Value(c_int, 0)
 
 
 class IngestIndexManager:


### PR DESCRIPTION
Fixes python 3.8 multiprocessing start method of `spawn` on macOS.