### PR TITLE
DM-23330: Doxygen warnings in pipe_base

### DIFF
--- a/ups/meas_algorithms.build
+++ b/ups/meas_algorithms.build
@@ -1,2 +1,0 @@
-@LSST BUILD@ &&
-build_lsst @PRODUCT@ @VERSION@ @REPOVERSION@

--- a/ups/meas_algorithms.cfg
+++ b/ups/meas_algorithms.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["astshim", "utils", "geom", "afw", "boost_math", "pex_config", "meas_base", "pipe_base",
+    "required": ["astshim", "utils", "geom", "afw", "boost_math", "pex_config", "meas_base",
                  "minuit2"],
     "buildRequired": ["boost_test", "pybind11"],
 }


### PR DESCRIPTION
This PR fixes a build error caused by converting `pipe_base` to a pure-Python package in lsst/pipe_base#184.