### PR TITLE
DM-30733: Make BrightStarStamps.initAndNormalize catch RuntimeExceptions

### DIFF
--- a/python/lsst/meas/algorithms/brightStarStamps.py
+++ b/python/lsst/meas/algorithms/brightStarStamps.py
@@ -274,7 +274,7 @@ class BrightStarStamps(StampsBase):
             try:
                 stamp.measureAndNormalize(annulus, statsControl=statsControl, statsFlag=statsFlag,
                                           badMaskPlanes=badMaskPlanes)
-            except ValueError:
+            except RuntimeError:
                 # Optionally keep NaN flux objects, for bookkeeping purposes,
                 # and to avoid having to re-find and redo the preprocessing
                 # steps needed before bright stars can be subtracted.


### PR DESCRIPTION
[Jira ticket](https://jira.lsstcorp.org/browse/DM-30733)