### PR TITLE
DM-26651: Change BrightStarStamp to save archive elements, positions, and number of rotations

### DIFF
--- a/python/lsst/meas/algorithms/brightStarStamps.py
+++ b/python/lsst/meas/algorithms/brightStarStamps.py
@@ -35,7 +35,7 @@ from lsst.afw import geom as afwGeom
 from lsst.afw import math as afwMath
 from lsst.afw import table as afwTable
 from lsst.geom import Point2I
-from .stamps import StampsBase, AbstractStamp, readFitsWithOptions
+from .stamps import Stamps, AbstractStamp, readFitsWithOptions
 
 
 @dataclass
@@ -148,7 +148,7 @@ class BrightStarStamp(AbstractStamp):
         return None
 
 
-class BrightStarStamps(StampsBase):
+class BrightStarStamps(Stamps):
     """Collection of bright star stamps and associated metadata.
 
     Parameters

--- a/python/lsst/meas/algorithms/brightStarStamps.py
+++ b/python/lsst/meas/algorithms/brightStarStamps.py
@@ -214,7 +214,8 @@ class BrightStarStamps(Stamps):
     @classmethod
     def initAndNormalize(cls, starStamps, innerRadius, outerRadius, nb90Rots=None,
                          metadata=None, use_mask=True, use_variance=False,
-                         imCenter=None, discardNanFluxObjects=True,
+                         use_archive=False, imCenter=None,
+                         discardNanFluxObjects=True,
                          statsControl=afwMath.StatisticsControl(),
                          statsFlag=afwMath.stringToStatisticsProperty("MEAN"),
                          badMaskPlanes=('BAD', 'SAT', 'NO_DATA')):
@@ -248,6 +249,11 @@ class BrightStarStamps(Stamps):
             If `True` read and write mask data. Default `True`.
         use_variance : `bool`
             If ``True`` read and write variance data. Default ``False``.
+        use_archive : `bool`
+            If ``True`` read and write an Archive that contains a Persistable
+            associated with each stamp. In the case of bright stars, this is
+            usually a ``TransformPoint2ToPoint2``, used to warp each stamp
+            to the same pixel grid before stacking.
         imCenter : `collections.abc.Sequence`, optional
             Center of the object, in pixels. If not provided, the center of the
             first stamp's pixel grid will be used.
@@ -283,7 +289,7 @@ class BrightStarStamps(Stamps):
         # Initialize (unnormalized) brightStarStamps instance
         bss = cls(starStamps, innerRadius=None, outerRadius=None, nb90Rots=nb90Rots,
                   metadata=metadata, use_mask=use_mask,
-                  use_variance=use_variance)
+                  use_variance=use_variance, use_archive=use_archive)
         # Ensure no stamps had already been normalized
         bss._checkNormalization(True, innerRadius, outerRadius)
         bss._innerRadius, bss._outerRadius = innerRadius, outerRadius


### PR DESCRIPTION
One of two PRs for DM-26651, [the other](https://github.com/lsst/pipe_tasks/pull/546) being in pipe_tasks.

[Jira ticket](https://jira.lsstcorp.org/browse/DM-26651)

[Jenkins run](https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/34567/pipeline)