### PR TITLE
DM-27843: Add anyFilterMapsToThis support to ReferenceObjectLoader

### DIFF
--- a/python/lsst/meas/algorithms/ingestIndexReferenceTask.py
+++ b/python/lsst/meas/algorithms/ingestIndexReferenceTask.py
@@ -41,7 +41,7 @@ import lsst.afw.table as afwTable
 from lsst.daf.base import PropertyList
 from .indexerRegistry import IndexerRegistry
 from .readTextCatalogTask import ReadTextCatalogTask
-from .loadReferenceObjects import LoadReferenceObjectsTask
+from .loadReferenceObjects import ReferenceObjectLoaderBase
 from . import convertRefcatManager
 
 # The most recent Indexed Reference Catalog on-disk format version.
@@ -414,7 +414,7 @@ class ConvertReferenceCatalogBase(pipeBase.Task, abc.ABC):
             - A map of catalog keys to use in filling the record
         """
         # make a schema with the standard fields
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(
             filterNameList=self.config.mag_column_list,
             addCentroid=False,
             addIsPhotometric=bool(self.config.is_photometric_name),

--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -643,7 +643,7 @@ class ReferenceObjectLoaderBase:
         return pipeBase.Struct(coord=coord, radius=radius, bbox=bbox)
 
     @staticmethod
-    def getMetadataCircle(coord, radius, filterName, photoCalib=None, epoch=None):
+    def getMetadataCircle(coord, radius, filterName, epoch=None):
         """Return metadata about the reference catalog being loaded.
 
         This metadata is used for reloading the catalog (e.g. for
@@ -657,8 +657,6 @@ class ReferenceObjectLoaderBase:
             Radius of the search region.
         filterName : `str`
             Name of the camera filter.
-        photoCalib : `None`
-            Deprecated, only included for api compatibility.
         epoch : `astropy.time.Time` or `None`, optional
             Epoch to which to correct proper motion and parallax, or `None` to
             not apply such corrections.
@@ -677,7 +675,7 @@ class ReferenceObjectLoaderBase:
         md.add('EPOCH', "NONE" if epoch is None else epoch.mjd, 'Epoch (TAI MJD) for catalog')
         return md
 
-    def getMetadataBox(self, bbox, wcs, filterName, photoCalib=None, epoch=None,
+    def getMetadataBox(self, bbox, wcs, filterName, epoch=None,
                        bboxToSpherePadding=100):
         """Return metadata about the load
 
@@ -692,8 +690,6 @@ class ReferenceObjectLoaderBase:
             The WCS object associated with ``bbox``.
         filterName : `str`
             Name of the camera filter.
-        photoCalib : `None`
-            Deprecated, only included for api compatibility.
         epoch : `astropy.time.Time` or `None`,  optional
             Epoch to which to correct proper motion and parallax, or `None` to
             not apply such corrections.

--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -774,7 +774,7 @@ class ReferenceObjectLoader(ReferenceObjectLoaderBase):
         self.refCats = refCats
         self.log = log or logging.getLogger(__name__).getChild("ReferenceObjectLoader")
 
-    def loadPixelBox(self, bbox, wcs, filterName, epoch=None, photoCalib=None,
+    def loadPixelBox(self, bbox, wcs, filterName, epoch=None,
                      bboxToSpherePadding=100):
         """Load reference objects that are within a pixel-based rectangular
         region.
@@ -802,8 +802,6 @@ class ReferenceObjectLoader(ReferenceObjectLoaderBase):
         epoch : `astropy.time.Time` or `None`, optional
             Epoch to which to correct proper motion and parallax, or `None`
             to not apply such corrections.
-        photoCalib : `None`
-            Deprecated and ignored, only included for api compatibility.
         bboxToSpherePadding : `int`, optional
             Padding to account for translating a set of corners into a
             spherical (convex) boundary that is certain to encompase the

--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -1081,7 +1081,7 @@ def getRefFluxKeys(schema, filterName):
 
 
 class LoadReferenceObjectsTask(pipeBase.Task, ReferenceObjectLoaderBase, metaclass=abc.ABCMeta):
-    """Abstract base class to load objects from reference catalogs.
+    """Abstract gen2 base class to load objects from reference catalogs.
     """
     _DefaultName = "LoadReferenceObjects"
 

--- a/tests/nopytest_ingestIndexReferenceCatalog.py
+++ b/tests/nopytest_ingestIndexReferenceCatalog.py
@@ -104,7 +104,7 @@ class TestConvertReferenceCatalogParallel(ingestIndexTestBase.ConvertReferenceCa
             loaderConfig = ReferenceObjectLoader.ConfigClass()
             loader = ReferenceObjectLoader([dataRef.dataId for dataRef in datasetRefs],
                                            handlers,
-                                           loaderConfig,
+                                           config=loaderConfig,
                                            log=self.logger)
             self.checkAllRowsInRefcat(loader, skyCatalog1, config)
             self.checkAllRowsInRefcat(loader, skyCatalog2, config)

--- a/tests/test_loadReferenceObjects.py
+++ b/tests/test_loadReferenceObjects.py
@@ -127,7 +127,9 @@ class TestReferenceObjectLoaderBase(lsst.utils.tests.TestCase):
             config.filterMap = filterMap
             loader = TrivialLoader(config=config)
             refSchema = TrivialLoader.makeMinimalSchema(filterNameList="r")
-            loader._addFluxAliases(refSchema)
+            loader._addFluxAliases(refSchema,
+                                   anyFilterMapsToThis=config.anyFilterMapsToThis,
+                                   filterMap=config.filterMap)
 
             self.assertIn("r_flux", refSchema)
             self.assertIn("r_fluxErr", refSchema)
@@ -165,12 +167,16 @@ class TestReferenceObjectLoaderBase(lsst.utils.tests.TestCase):
         config.anyFilterMapsToThis = "gg"
         loader = TrivialLoader(config=config)
         refSchema = TrivialLoader.makeMinimalSchema(filterNameList=["gg"])
-        loader._addFluxAliases(refSchema)
+        loader._addFluxAliases(refSchema,
+                               anyFilterMapsToThis=config.anyFilterMapsToThis,
+                               filterMap=config.filterMap)
         self.assertEqual(getRefFluxField(refSchema, "r"), "gg_flux")
         # raise if "gg" is not in the refcat filter list
         with self.assertRaises(RuntimeError):
             refSchema = TrivialLoader.makeMinimalSchema(filterNameList=["rr"])
-            refSchema = loader._addFluxAliases(refSchema)
+            refSchema = loader._addFluxAliases(refSchema,
+                                               anyFilterMapsToThis=config.anyFilterMapsToThis,
+                                               filterMap=config.filterMap)
 
     def testCheckFluxUnits(self):
         """Test that we can identify old style fluxes in a schema."""

--- a/tests/test_loadReferenceObjects.py
+++ b/tests/test_loadReferenceObjects.py
@@ -89,9 +89,9 @@ class TestReferenceObjectLoaderBase(lsst.utils.tests.TestCase):
                 if coordErrDim not in (0, 2, 3) or \
                         (addProperMotion and properMotionErrDim not in (0, 2, 3)):
                     with self.assertRaises(ValueError):
-                        LoadReferenceObjectsTask.makeMinimalSchema(**argDict)
+                        ReferenceObjectLoaderBase.makeMinimalSchema(**argDict)
                 else:
-                    refSchema = LoadReferenceObjectsTask.makeMinimalSchema(**argDict)
+                    refSchema = ReferenceObjectLoaderBase.makeMinimalSchema(**argDict)
                     self.assertTrue("coord_ra" in refSchema)
                     self.assertTrue("coord_dec" in refSchema)
                     for filterName in filterNameList:
@@ -174,29 +174,29 @@ class TestReferenceObjectLoaderBase(lsst.utils.tests.TestCase):
 
     def testCheckFluxUnits(self):
         """Test that we can identify old style fluxes in a schema."""
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
         # the default schema should pass
         self.assertTrue(hasNanojanskyFluxUnits(schema))
         schema.addField('bad_fluxSigma', doc='old flux units', type=float, units='')
         self.assertFalse(hasNanojanskyFluxUnits(schema))
 
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
         schema.addField('bad_flux', doc='old flux units', type=float, units='')
         self.assertFalse(hasNanojanskyFluxUnits(schema))
 
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
         schema.addField('bad_flux', doc='old flux units', type=float, units='Jy')
         self.assertFalse(hasNanojanskyFluxUnits(schema))
 
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
         schema.addField('bad_fluxErr', doc='old flux units', type=float, units='')
         self.assertFalse(hasNanojanskyFluxUnits(schema))
 
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
         schema.addField('bad_fluxErr', doc='old flux units', type=float, units='Jy')
         self.assertFalse(hasNanojanskyFluxUnits(schema))
 
-        schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+        schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
         schema.addField('bad_fluxSigma', doc='old flux units', type=float, units='')
         self.assertFalse(hasNanojanskyFluxUnits(schema))
 
@@ -207,7 +207,7 @@ class TestReferenceObjectLoaderBase(lsst.utils.tests.TestCase):
         log = lsst.log.Log()
 
         def make_catalog():
-            schema = LoadReferenceObjectsTask.makeMinimalSchema(['r', 'z'])
+            schema = ReferenceObjectLoaderBase.makeMinimalSchema(['r', 'z'])
             schema.addField('bad_flux', doc='old flux units', type=float, units='')
             schema.addField('bad_fluxErr', doc='old flux units', type=float, units='Jy')
             refCat = afwTable.SimpleCatalog(schema)

--- a/tests/test_loadReferenceObjects.py
+++ b/tests/test_loadReferenceObjects.py
@@ -26,22 +26,22 @@ import unittest
 
 import lsst.afw.table as afwTable
 import lsst.log
-from lsst.meas.algorithms import LoadReferenceObjectsTask, getRefFluxField, getRefFluxKeys
+from lsst.meas.algorithms import ReferenceObjectLoaderBase, getRefFluxField, getRefFluxKeys
 from lsst.meas.algorithms.loadReferenceObjects import hasNanojanskyFluxUnits, convertToNanojansky
 import lsst.pex.config
 import lsst.utils.tests
 
 
-class TrivialLoader(LoadReferenceObjectsTask):
-    """Minimal subclass of LoadReferenceObjectsTask to allow instantiation
+class TrivialLoader(ReferenceObjectLoaderBase):
+    """Minimal subclass of ReferenceObjectLoaderBase to allow instantiation
     """
 
     def loadSkyCircle(self, ctrCoord, radius, filterName):
         pass
 
 
-class TestLoadReferenceObjects(lsst.utils.tests.TestCase):
-    """Test case for LoadReferenceObjectsTask abstract base class
+class TestReferenceObjectLoaderBase(lsst.utils.tests.TestCase):
+    """Test case for ReferenceObjectLoaderBase abstract base class.
 
     Only methods with concrete implementations are tested (hence not loadSkyCircle)
     """


### PR DESCRIPTION
As part of getting the gen3 code to support the more complicated filter mapping logic that the gen2 code did, I also refactored several methods into the common base class. Gen2 is going away soon, but we also want to keep as much of the gen2 test coverage as we can: this should help with that.