### PR TITLE
DM-35105 Force (0, 0) for center of warped PSF images.

### DIFF
--- a/src/WarpedPsf.cc
+++ b/src/WarpedPsf.cc
@@ -89,11 +89,11 @@ geom::Box2I computeBBoxFromTransform(geom::Box2I const bbox, geom::AffineTransfo
     }
 
     // We want to guarantee that the output bbox has odd dimensions, so instead
-    // of using the Box2I converting constructor directly, we round the center
-    // point of the floating point box and dilate by its half-dimensions.
+    // of using the Box2I converting constructor directly, we start with (0, 0)
+    // and dilate by the floating-point box's half-dimensions.
     geom::Extent2I out_half_dims = geom::floor(0.5*out_box_fp.getDimensions());
     geom::Box2I out_box;
-    geom::Point2I out_center(out_box_fp.getCenter());
+    geom::Point2I out_center(0, 0);
     out_box.include(out_center);
     return out_box.dilatedBy(out_half_dims);
 }
@@ -124,6 +124,7 @@ std::shared_ptr<afw::detection::Psf::Image> warpAffine(afw::detection::Psf::Imag
 
     // allocate output image
     geom::Box2I bbox = computeBBoxFromTransform(im.getBBox(), srcToDest);
+
     auto ret = std::make_shared<afw::detection::Psf::Image>(bbox);
 
     // zero-pad input image


### PR DESCRIPTION
Previous logic forced the image size to be odd, but picked the center of the kernel image bbox based on center of the transformed kernel image bbox.  But the output kernel image center is an input: (0, 0).

This manifested as even-sizes images later in CoaddPsf; the union of two odd-sized boxes with the same dimensions but offset center is an even-sized box.