### PR TITLE
DM-22823: Remove accidental Doxygen comments for namespaces

### DIFF
--- a/src/CR.cc
+++ b/src/CR.cc
@@ -50,9 +50,9 @@
 #include "lsst/meas/algorithms/CR.h"
 #include "lsst/meas/algorithms/Interp.h"
 
-/**
- * @todo These should go into afw --- actually, there're already there, but
- * in an anon namespace
+/*
+ * TODO: These should go into afw --- actually, there're already there, but
+ * in an anon namespace (DM-35750).
  */
 namespace lsst {
 namespace afw {

--- a/src/SpatialModelPsf.cc
+++ b/src/SpatialModelPsf.cc
@@ -677,9 +677,6 @@ std::pair<bool, double> fitSpatialKernelFromPsfCandidates(
 }
 
 /************************************************************************************************************/
-/**
- * Fit spatial kernel using approximate fluxes for candidates, and solving a linear system of equations
- */
 namespace {
 /// A class to calculate the A and b matrices used to estimate the PSF's spatial structure
 ///
@@ -872,6 +869,9 @@ public:
 
 }  // namespace
 
+/**
+ * Fit spatial kernel using approximate fluxes for candidates, and solving a linear system of equations
+ */
 template <typename PixelT>
 std::pair<bool, double> fitSpatialKernelFromPsfCandidates(
         afw::math::Kernel* kernel,                  ///< the Kernel to fit


### PR DESCRIPTION
This PR removes or rearranges Doxygen comments that were intended to be file-level (or, in one case, block-level) but instead described namespaces.