### PR TITLE
DM-38667: Putting a condition on the minimum number of valid pixels within the normalisation annulus

### DIFF
--- a/python/lsst/meas/algorithms/brightStarStamps.py
+++ b/python/lsst/meas/algorithms/brightStarStamps.py
@@ -64,8 +64,9 @@ class BrightStarStamp(AbstractStamp):
     gaiaId: int
     position: Point2I
     archive_element: Persistable | None = None
-    annularFlux: float | None = None
+    # annularFlux: float | None = None
     minPixelsWithinAnnulus: float = 0.0
+    log.configure()
 
     @classmethod
     def factory(cls, stamp_im, metadata, idx, archive_element=None, minPixelsWithinAnnulus=0.0):

--- a/python/lsst/meas/algorithms/brightStarStamps.py
+++ b/python/lsst/meas/algorithms/brightStarStamps.py
@@ -64,9 +64,8 @@ class BrightStarStamp(AbstractStamp):
     gaiaId: int
     position: Point2I
     archive_element: Persistable | None = None
-    # annularFlux: float | None = None
+    annularFlux: float | None = None
     minPixelsWithinAnnulus: float = 0.0
-    log.configure()
 
     @classmethod
     def factory(cls, stamp_im, metadata, idx, archive_element=None, minPixelsWithinAnnulus=0.0):


### PR DESCRIPTION
This condition results in the rejection of bright star stamps with less valid pixels within the normalisation annulus than what the user determines.

In addition, some modifications have been made to reject stamps with a negative normalisation factor.