### PR TITLE
DM-39306: Change excludeMaskPlanes to not exclude any by default.

### DIFF
--- a/python/lsst/meas/algorithms/detection.py
+++ b/python/lsst/meas/algorithms/detection.py
@@ -145,7 +145,7 @@ class SourceDetectionConfig(pexConfig.Config):
     )
     excludeMaskPlanes = lsst.pex.config.ListField(
         dtype=str,
-        default=("EDGE",),
+        default=[],
         doc="Mask planes to exclude when detecting sources."
     )
 


### PR DESCRIPTION
This PR overrides the global default from DM-38246 because it was harming several metrics.