### PR TITLE
DM-39828: Use 'Catalog.__getitem__' instead of 'get' in selectors.

### DIFF
--- a/python/lsst/meas/algorithms/astrometrySourceSelector.py
+++ b/python/lsst/meas/algorithms/astrometrySourceSelector.py
@@ -99,7 +99,7 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
         """
         self._getSchemaKeys(sourceCat.schema)
 
-        bad = reduce(lambda x, y: np.logical_or(x, sourceCat.get(y)), self.config.badFlags, False)
+        bad = reduce(lambda x, y: np.logical_or(x, sourceCat[y]), self.config.badFlags, False)
         good = self._isGood(sourceCat)
         return Struct(selected=good & ~bad)
 
@@ -130,7 +130,7 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
     def _isMultiple(self, sourceCat):
         """Return True for each source that is likely multiple sources.
         """
-        test = (sourceCat.get(self.parentKey) != 0) | (sourceCat.get(self.nChildKey) != 0)
+        test = (sourceCat[self.parentKey] != 0) | (sourceCat[self.nChildKey] != 0)
         # have to currently manage footprints on a source-by-source basis.
         for i, cat in enumerate(sourceCat):
             footprint = cat.getFootprint()
@@ -143,13 +143,13 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
         def checkNonfiniteCentroid():
             """Return True for sources with non-finite centroids.
             """
-            return ~np.isfinite(sourceCat.get(self.centroidXKey)) | \
-                ~np.isfinite(sourceCat.get(self.centroidYKey))
+            return ~np.isfinite(sourceCat[self.centroidXKey]) | \
+                ~np.isfinite(sourceCat[self.centroidYKey])
         assert ~checkNonfiniteCentroid().any(), \
             "Centroids not finite for %d unflagged sources." % (checkNonfiniteCentroid().sum())
-        return np.isfinite(sourceCat.get(self.centroidXErrKey)) \
-            & np.isfinite(sourceCat.get(self.centroidYErrKey)) \
-            & ~sourceCat.get(self.centroidFlagKey)
+        return np.isfinite(sourceCat[self.centroidXErrKey]) \
+            & np.isfinite(sourceCat[self.centroidYErrKey]) \
+            & ~sourceCat[self.centroidFlagKey]
 
     def _goodSN(self, sourceCat):
         """Return True for each source that has Signal/Noise > config.minSnr.
@@ -158,7 +158,7 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
             return True
         else:
             with np.errstate(invalid="ignore"):  # suppress NAN warnings
-                return sourceCat.get(self.instFluxKey)/sourceCat.get(self.instFluxErrKey) > self.config.minSnr
+                return sourceCat[self.instFluxKey]/sourceCat[self.instFluxErrKey] > self.config.minSnr
 
     def _isUsable(self, sourceCat):
         """Return True for each source that is usable for matching, even if it may
@@ -174,13 +174,13 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
         return self._hasCentroid(sourceCat) \
             & ~self._isMultiple(sourceCat) \
             & self._goodSN(sourceCat) \
-            & ~sourceCat.get(self.fluxFlagKey)
+            & ~sourceCat[self.fluxFlagKey]
 
     def _isPrimary(self, sourceCat):
         """Return True if this is a primary source.
         """
         if self.primaryKey:
-            return sourceCat.get(self.primaryKey)
+            return sourceCat[self.primaryKey]
         else:
             return np.ones(len(sourceCat), dtype=bool)
 
@@ -196,11 +196,11 @@ class AstrometrySourceSelectorTask(BaseSourceSelectorTask):
 
         return self._isUsable(sourceCat) \
             & self._isPrimary(sourceCat) \
-            & ~sourceCat.get(self.saturatedKey) \
-            & ~sourceCat.get(self.interpolatedCenterKey) \
-            & ~sourceCat.get(self.edgeKey)
+            & ~sourceCat[self.saturatedKey] \
+            & ~sourceCat[self.interpolatedCenterKey] \
+            & ~sourceCat[self.edgeKey]
 
     def _isBadFlagged(self, source):
         """Return True if any of config.badFlags are set for this source.
         """
-        return any(source.get(flag) for flag in self.config.badFlags)
+        return any(source[flag] for flag in self.config.badFlags)

--- a/python/lsst/meas/algorithms/astrometrySourceSelector.py
+++ b/python/lsst/meas/algorithms/astrometrySourceSelector.py
@@ -1,10 +1,10 @@
+# This file is part of meas_algorithms.
 #
-# LSST Data Management System
-#
-# Copyright 2008-2017  AURA/LSST.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,10 +16,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <https://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Select sources that are useful for astrometry.
 
 Such sources have good signal-to-noise, are well centroided, not blended,

--- a/python/lsst/meas/algorithms/flaggedSourceSelector.py
+++ b/python/lsst/meas/algorithms/flaggedSourceSelector.py
@@ -1,10 +1,10 @@
+# This file is part of meas_algorithms.
 #
-# LSST Data Management System
-#
-# Copyright 2008-2017  AURA/LSST.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,10 +16,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <https://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 """Select sources that have an existing flag field set."""
 import lsst.pex.config
 import lsst.afw.table

--- a/python/lsst/meas/algorithms/flaggedSourceSelector.py
+++ b/python/lsst/meas/algorithms/flaggedSourceSelector.py
@@ -82,4 +82,4 @@ class FlaggedSourceSelectorTask(BaseSourceSelectorTask):
                 ``sourceCat``. (`numpy.ndarray` of `bool`)
         """
         key = sourceCat.schema.find(self.config.field).key
-        return pipeBase.Struct(selected=sourceCat.get(key))
+        return pipeBase.Struct(selected=sourceCat[key])

--- a/python/lsst/meas/algorithms/matcherSourceSelector.py
+++ b/python/lsst/meas/algorithms/matcherSourceSelector.py
@@ -1,10 +1,10 @@
+# This file is part of meas_algorithms.
 #
-# LSST Data Management System
-#
-# Copyright 2008-2017  AURA/LSST.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,10 +16,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <https://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = ["MatcherSourceSelectorConfig", "MatcherSourceSelectorTask"]
 

--- a/python/lsst/meas/algorithms/matcherSourceSelector.py
+++ b/python/lsst/meas/algorithms/matcherSourceSelector.py
@@ -116,15 +116,15 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
     def _isParent(self, sourceCat):
         """Return True for each source that is the parent source.
         """
-        test = (sourceCat.get(self.parentKey) == 0)
+        test = (sourceCat[self.parentKey] == 0)
         return test
 
     def _hasCentroid(self, sourceCat):
         """Return True for each source that has a valid centroid
         """
-        return np.isfinite(sourceCat.get(self.centroidXKey)) \
-            & np.isfinite(sourceCat.get(self.centroidYKey)) \
-            & ~sourceCat.get(self.centroidFlagKey)
+        return np.isfinite(sourceCat[self.centroidXKey]) \
+            & np.isfinite(sourceCat[self.centroidYKey]) \
+            & ~sourceCat[self.centroidFlagKey]
 
     def _goodSN(self, sourceCat):
         """Return True for each source that has Signal/Noise > config.minSnr.
@@ -133,7 +133,7 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
             return True
         else:
             with np.errstate(invalid="ignore"):  # suppress NAN warnings
-                return sourceCat.get(self.fluxKey)/sourceCat.get(self.fluxErrKey) > self.config.minSnr
+                return sourceCat[self.fluxKey]/sourceCat[self.fluxErrKey] > self.config.minSnr
 
     def _isUsable(self, sourceCat):
         """
@@ -150,7 +150,7 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
         return self._hasCentroid(sourceCat) \
             & self._isParent(sourceCat) \
             & self._goodSN(sourceCat) \
-            & ~sourceCat.get(self.fluxFlagKey)
+            & ~sourceCat[self.fluxFlagKey]
 
     def _isGood(self, sourceCat):
         """
@@ -163,6 +163,6 @@ class MatcherSourceSelectorTask(BaseSourceSelectorTask):
         - Not have an interpolated pixel within 3x3 around their centroid.
         - Not have a saturated pixel in their footprint.
         """
-        return ~sourceCat.get(self.edgeKey) & \
-               ~sourceCat.get(self.interpolatedCenterKey) & \
-               ~sourceCat.get(self.saturatedKey)
+        return ~sourceCat[self.edgeKey] & \
+               ~sourceCat[self.interpolatedCenterKey] & \
+               ~sourceCat[self.saturatedKey]

--- a/python/lsst/meas/algorithms/objectSizeStarSelector.py
+++ b/python/lsst/meas/algorithms/objectSizeStarSelector.py
@@ -367,8 +367,8 @@ class ObjectSizeStarSelectorTask(BaseSourceSelectorTask):
         #
         # Look at the distribution of stars in the magnitude-size plane
         #
-        flux = sourceCat.get(self.config.sourceFluxField)
-        fluxErr = sourceCat.get(self.config.sourceFluxField + "Err")
+        flux = sourceCat[self.config.sourceFluxField]
+        fluxErr = sourceCat[self.config.sourceFluxField + "Err"]
 
         xx = numpy.empty(len(sourceCat))
         xy = numpy.empty_like(xx)
@@ -386,7 +386,7 @@ class ObjectSizeStarSelectorTask(BaseSourceSelectorTask):
 
         width = numpy.sqrt(0.5*(xx + yy))
         with numpy.errstate(invalid="ignore"):  # suppress NAN warnings
-            bad = reduce(lambda x, y: numpy.logical_or(x, sourceCat.get(y)), self.config.badFlags, False)
+            bad = reduce(lambda x, y: numpy.logical_or(x, sourceCat[y]), self.config.badFlags, False)
             bad = numpy.logical_or(bad, numpy.logical_not(numpy.isfinite(width)))
             bad = numpy.logical_or(bad, numpy.logical_not(numpy.isfinite(flux)))
             if self.config.doFluxLimit:

--- a/python/lsst/meas/algorithms/sourceSelector.py
+++ b/python/lsst/meas/algorithms/sourceSelector.py
@@ -1,10 +1,10 @@
+# This file is part of meas_algorithms.
 #
-# LSST Data Management System
-#
-# Copyright 2008-2017  AURA/LSST.
-#
-# This product includes software developed by the
-# LSST Project (http://www.lsst.org/).
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,10 +16,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program.  If not,
-# see <https://www.lsstcorp.org/LegalNotices/>.
-#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 __all__ = ["BaseSourceSelectorConfig", "BaseSourceSelectorTask", "sourceSelectorRegistry",
            "ColorLimit", "MagnitudeLimit", "SignalToNoiseLimit", "MagnitudeErrorLimit",


### PR DESCRIPTION
'get' actually invokes the ColumnView method via __getattr__ forwarding, and that's less capable than Catalog.__getitem__ as well as being a pointless forward to ColumnView.__getitem__ that probably never needed to exist.