### PR TITLE
DM-45468: Add obs_base dependency

### DIFF
--- a/ups/meas_algorithms.table
+++ b/ups/meas_algorithms.table
@@ -11,6 +11,7 @@ setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(cpputils)
 setupRequired(kht)
+setupRequired(obs_base)
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 envPrepend(DYLD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
Needed to be able to use the generic fits formatter.