### PR TITLE
DM-43620: When reading stamps, ignore non-image binary tables

### DIFF
--- a/python/lsst/meas/algorithms/stamps.py
+++ b/python/lsst/meas/algorithms/stamps.py
@@ -168,6 +168,10 @@ def readFitsWithOptions(filename, stamp_factory, options):
         for idx in range(nExtensions - 1):
             dtype = None
             md = readMetadata(filename, hdu=idx + 1)
+            # Skip binary tables that aren't images or archives.
+            if md["XTENSION"] == "BINTABLE" and not ("ZIMAGE" in md and md["ZIMAGE"]):
+                if md["EXTNAME"] != "ARCHIVE_INDEX":
+                    continue
             if md["EXTNAME"] in ("IMAGE", "VARIANCE"):
                 reader = ImageFitsReader(filename, hdu=idx + 1)
                 if md["EXTNAME"] == "VARIANCE":


### PR DESCRIPTION
Raw guider images have additional tables that can not be read but should be ignored to allow the rest of the data to be read.