### PR TITLE
DM-47385: Refine mask exclusion behavior in removeBadPixels (aka cancel original masks)

### DIFF
--- a/python/lsst/meas/algorithms/detection.py
+++ b/python/lsst/meas/algorithms/detection.py
@@ -774,7 +774,7 @@ class SourceDetectionTask(pipeBase.Task):
             convolveResults = self.convolveImage(maskedImage, psf, doSmooth=doSmooth)
             middle = convolveResults.middle
             sigma = convolveResults.sigma
-            self.removeBadPixels(middle, exposure.maskedImage.mask)
+            self.removeBadPixels(middle)
 
             results = self.applyThreshold(middle, maskedImage.getBBox())
             results.background = background if background is not None else afwMath.BackgroundList()
@@ -799,20 +799,17 @@ class SourceDetectionTask(pipeBase.Task):
 
         return results
 
-    def removeBadPixels(self, middle, mask):
+    def removeBadPixels(self, middle):
         """Set the significance of flagged pixels to zero.
 
         Parameters
         ----------
-        middle : `lsst.afw.image.Exposure` or `lsst.afw.image.MaskedImage`
-            Convolved image to zero certain mask planes from.
+        middle : `lsst.afw.image.Exposure`
+            Score or maximum likelihood difference image.
             The image plane will be modified in place.
-        mask : `lsst.afw.image.Mask`
-            Mask to select planes from to zero the image; will be restricted
-            to the image's bounding box.
         """
-        badPixelMask = mask.getPlaneBitMask(self.config.excludeMaskPlanes)
-        badPixels = mask.subset(middle.getBBox()).array & badPixelMask > 0
+        badPixelMask = middle.mask.getPlaneBitMask(self.config.excludeMaskPlanes)
+        badPixels = middle.mask.array & badPixelMask > 0
         middle.image.array[badPixels] = 0
 
     def setPeakSignificance(self, exposure, footprints, threshold, negative=False):


### PR DESCRIPTION
In principle, convolution-induced mask growth may block some good sources near zeroed-out regions, so we switched to the original masked regions. Unfortunately in practice, bogus diaSources appeared near masked regions, so we are undoing this change and  living with losing some edge-y diaSources.