### PR TITLE
DM-49554: Add pixelFlags plugin to dynamic detection forced measurement

### DIFF
--- a/python/lsst/meas/algorithms/dynamicDetection.py
+++ b/python/lsst/meas/algorithms/dynamicDetection.py
@@ -105,7 +105,10 @@ class DynamicDetectionTask(SourceDetectionTask):
 
         # Set up forced measurement.
         config = ForcedMeasurementTask.ConfigClass()
-        config.plugins.names = ['base_TransformedCentroid', 'base_PsfFlux', 'base_LocalBackground']
+        config.plugins.names = ['base_TransformedCentroid',
+                                'base_PsfFlux',
+                                'base_LocalBackground',
+                                'base_PixelFlags']
         # We'll need the "centroid" and "psfFlux" slots
         for slot in ("shape", "psfShape", "apFlux", "modelFlux", "gaussianFlux", "calibFlux"):
             setattr(config.slots, slot, None)


### PR DESCRIPTION
This PR adds `base_PixelFlags` to the forced measurement part of dynamic detection, because it is now an expected plugin every time forced measurement is run.