### PR TITLE
DM-48718: raise 'NoWorkFound' in SubtractBackgroundTask when all pixels are masked

### DIFF
--- a/python/lsst/meas/algorithms/subtractBackground.py
+++ b/python/lsst/meas/algorithms/subtractBackground.py
@@ -317,7 +317,7 @@ class SubtractBackgroundTask(pipeBase.Task):
 
         self.log.debug("Ignoring mask planes: %s", ", ".join(self.config.ignoredPixelMask))
         if (maskedImage.mask.getArray() & badMask).all():
-            raise pipeBase.TaskError("All pixels masked. Cannot estimate background")
+            raise pipeBase.NoWorkFound("All pixels masked. Cannot estimate background")
 
         if algorithm is None:
             algorithm = self.config.algorithm


### PR DESCRIPTION
This  change is to distinguish background subtraction errors in detection when we don't expect them to succeed because all of the exposure pixels are masked.