### PR TITLE
DM-51053: Switch to vectorized refcat filtering

### DIFF
--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -109,10 +109,10 @@ class _FilterCatalog:
             # no filtering needed, region completely contains refcat
             return refCat
 
-        filteredRefCat = type(refCat)(refCat.table)
-        for record in refCat:
-            if self.region.contains(record.getCoord().getVector()):
-                filteredRefCat.append(record)
+        coordKey = refCat.getCoordKey()
+        inside = self.region.contains(lon=refCat[coordKey.getRa()], lat=refCat[coordKey.getDec()])
+        filteredRefCat = refCat[inside]
+
         return filteredRefCat
 
 

--- a/python/lsst/meas/algorithms/loadReferenceObjects.py
+++ b/python/lsst/meas/algorithms/loadReferenceObjects.py
@@ -599,14 +599,10 @@ class ReferenceObjectLoader:
             # region defined by the inner sky region.
             if innerSkyRegion.contains(region):
                 return refCat
-            # Create a new reference catalog, and populate it only with records
-            # that fall inside the padded bbox.
-            filteredRefCat = type(refCat)(refCat.table)
-            centroidKey = afwTable.Point2DKey(refCat.schema['centroid'])
-            for record in refCat:
-                pixCoords = record[centroidKey]
-                if paddedBbox.contains(geom.Point2D(pixCoords)):
-                    filteredRefCat.append(record)
+
+            inside = paddedBbox.contains(x=refCat["slot_Centroid_x"], y=refCat["slot_Centroid_y"])
+            filteredRefCat = refCat[inside]
+
             return filteredRefCat
         return self.loadRegion(outerSkyRegion, filterName, filtFunc=_filterFunction, epoch=epoch)
 


### PR DESCRIPTION
Turns out for dense fields half the refcat loading time is due to non-vectorized filtering.