### PR TITLE
DM-51361: Catch NaN values when using background filtering.

### DIFF
--- a/python/lsst/meas/algorithms/subtractBackground.py
+++ b/python/lsst/meas/algorithms/subtractBackground.py
@@ -426,5 +426,9 @@ def filterSuperPixels(bbox, background, superPixelFilterSize=3):
         Size of the median filter to use, in pixels.
     """
     statsImg = background.getStatsImage()
-    statsImg.image.array = median_filter(statsImg.image.array, mode='reflect', size=superPixelFilterSize)
+    # scipy's median_filter can't handle NaN values
+    bad = numpy.isnan(statsImg.image.array)
+    if numpy.count_nonzero(bad) > 0:
+        statsImg.image.array[bad] = numpy.nanmedian(statsImg.image.array)
+    statsImg.image.array = median_filter(statsImg.image.array, mode="reflect", size=superPixelFilterSize)
     background = afwMath.BackgroundMI(bbox, statsImg)


### PR DESCRIPTION
The function `scipy.ndimage.median_filter` that is used for the filtering has undefined behavior when NaN values are present. These should all be masked, but interpolation can lead to pixels near the masked regions being affected.